### PR TITLE
Improve Authentication page

### DIFF
--- a/docs-ref-conceptual/python-sdk-azure-authenticate.md
+++ b/docs-ref-conceptual/python-sdk-azure-authenticate.md
@@ -119,7 +119,7 @@ client = ComputeManagementClient(credentials, subscription_id)
 > When using an Azure sovereign cloud you must also specify the appropriate base URL (via the constants in `msrestazure.azure_cloud`) when creating the management client. For example for Azure China Cloud:
 > ```python
 > client = ComputeManagementClient(credentials, subscription_id,
-      base_url=AZURE_CHINA_CLOUD.endpoints.active_directory_resource_id)
+>     base_url=AZURE_CHINA_CLOUD.endpoints.active_directory_resource_id)
 > ```
 
 ## <a name="mgmt-auth-file"></a>File based authentication

--- a/docs-ref-conceptual/python-sdk-azure-authenticate.md
+++ b/docs-ref-conceptual/python-sdk-azure-authenticate.md
@@ -5,7 +5,7 @@ keywords: Azure, Python, SDK, API, authentication, active directory, service pri
 author: lisawong19
 ms.author: liwong
 manager: douge
-ms.date: 06/13/2017
+ms.date: 07/24/2017
 ms.topic: article
 ms.technology: azure
 ms.devlang: python
@@ -15,50 +15,155 @@ ms.assetid:
 
 # Authenticate with the Azure Management Libraries for Python
 
-## <a name="mgmt-auth"></a>Azure management libraries for Python authentication
-
 Several options are available to authenticate your application with Azure when using the Python management libraries to create and manage resources.
 
-### Authenticate with token credentials
+## <a name="mgmt-auth-token"></a>Authenticate with token credentials
 
-Store the credentials securely in a configuration file, the registry, or Azure KeyVault. It is recommended to use [ADAL](https://github.com/AzureAD/azure-activedirectory-library-for-python)
+Store the credentials securely in a configuration file, the registry, or Azure KeyVault.
+
+The following example uses a [Service Principal](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli?toc=%2fazure%2fazure-resource-manager%2ftoc.json) for authentication.
+
+> [!NOTE]
+> You can create a Service Principal via the Azure CLI 2.0
+> ```bash
+> az ad sp create-for-rbac --name "MY-PRINCIPAL-NAME" --password "STRONG-SECRET-PASSWORD"
+> ```
+
+```python
+    from azure.common.credentials import ServicePrincipalCredentials
+
+    # Tenant ID for your Azure Subscription
+    TENANT_ID = 'ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL'
+
+    # Your Service Principal App ID
+    CLIENT = 'a2ab11af-01aa-4759-8345-7803287dbd39'
+
+    # Your Service Principal Password
+    KEY = 'password'
+
+    credentials = ServicePrincipalCredentials(
+        client_id = CLIENT,
+        secret = KEY,
+        tenant = TENANT_ID
+    )
+```
+
+> [Note!]
+> To connect to one of the Azure sovereign clouds, use the `cloud_environment` parameter.
+
+```python
+    from azure.common.credentials import ServicePrincipalCredentials
+    from msrestazure.azure_cloud import AZURE_CHINA_CLOUD
+
+    # Tenant ID for your Azure Subscription
+    TENANT_ID = 'ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL'
+
+    # Your Service Principal App ID
+    CLIENT = 'a2ab11af-01aa-4759-8345-7803287dbd39'
+
+    # Your Service Principal Password
+    KEY = 'password'
+
+    credentials = ServicePrincipalCredentials(
+        client_id = CLIENT,
+        secret = KEY,
+        tenant = TENANT_ID,
+        cloud_environment = AZURE_CHINA_CLOUD
+    )
+```
+
+If you need more control, it is recommended to use [ADAL](https://github.com/AzureAD/azure-activedirectory-library-for-python)
 and the SDK ADAL wrapper. Please refer to the ADAL website for all the available scenarios
 list and samples. For instance for service principal authentication:
 
 ```python
     import adal
     from msrestazure.azure_active_directory import AdalAuthentication
+    from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 
-    login_endpoint = 'https://login.microsoftonline.com/'
-    tenant = 'ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL'
-    resource = 'https://management.core.windows.net/' #AAD graph resource
+    # Tenant ID for your Azure Subscription
+    TENANT_ID = 'ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL'
 
-    client = 'a2ab11af-01aa-4759-8345-7803287dbd39'
-    key = 'password'
+    # Your Service Principal App ID
+    CLIENT = 'a2ab11af-01aa-4759-8345-7803287dbd39'
 
-    context = adal.AuthenticationContext(LOGIN_ENDPOINT+TENANT)
+    # Your Service Principal Password
+    KEY = 'password'
+
+    LOGIN_ENDPOINT = AZURE_PUBLIC_CLOUD.endpoints.active_directory
+    RESOURCE = AZURE_PUBLIC_CLOUD.endpoints.active_directory_resource_id
+
+    context = adal.AuthenticationContext(LOGIN_ENDPOINT + '/' + TENANT_ID)
     credentials = AdalAuthentication(
         context.acquire_token_with_client_credentials,
-        resource,
-        client,
-        key
+        RESOURCE,
+        CLIENT,
+        KEY
     )
 ```
 
 All ADAL valid calls can be used with the `AdalAuthentication` class.
 
-Then create a client object to start working with the API:
+Next, create a client object to start working with the API:
 
 ```python
 from azure.mgmt.compute import ComputeManagementClient
 
-# change for your actual subscription id
+# Your Azure Subscription ID
 subscription_id = '33333333-3333-3333-3333-333333333333'
 
 client = ComputeManagementClient(credentials, subscription_id)
 ```
 
-### CLI-based authentication
+> [Note!]
+> When using an Azure sovereign cloud you must also specify the appropriate base URL (via the constants in `msrestazure.azure_cloud`) when creating the management client. For example for Azure China Cloud:
+> ```python
+> client = ComputeManagementClient(credentials, subscription_id,
+      base_url=AZURE_CHINA_CLOUD.endpoints.active_directory_resource_id)
+> ```
+
+## <a name="mgmt-auth-file"></a>File based authentication
+
+The simplest way to authenticate is to create a JSON file that contains credentials for an Azure Service Principal. You can use
+the following CLI command to create a new Service Principal and this file at the same time:
+
+```bash
+az ad sp create-for-rbac --sdk-auth > mycredentials.json
+```
+
+Save this file in a secure location on your system where your code can read it. Set an environment variable with the full path to the file in your shell:
+
+```bash
+export AZURE_AUTH_LOCATION=~/.azure/azure_credentials.json
+```
+
+If you want to create the file yourself, please follow this format:
+
+```json
+{
+    "clientId": "ad735158-65ca-11e7-ba4d-ecb1d756380e",
+    "clientSecret": "b70bb224-65ca-11e7-810c-ecb1d756380e",
+    "subscriptionId": "bfc42d3a-65ca-11e7-95cf-ecb1d756380e",
+    "tenantId": "c81da1d8-65ca-11e7-b1d1-ecb1d756380e",
+    "activeDirectoryEndpointUrl": "https://login.microsoftonline.com",
+    "resourceManagerEndpointUrl": "https://management.azure.com/",
+    "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+    "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/",
+    "galleryEndpointUrl": "https://gallery.azure.com/",
+    "managementEndpointUrl": "https://management.core.windows.net/"
+}
+```
+
+You can then create any client using the client factory:
+```python
+from azure.common.client_factory import get_client_from_auth_file
+from azure.mgmt.compute import ComputeManagementClient
+
+client = get_client_from_auth_file(ComputeManagementClient)
+```
+
+
+## <a name="mgmt-auth-cli"></a>CLI-based authentication
 
 The SDK is able to create a client using your CLI active subscription.
 
@@ -78,10 +183,9 @@ from azure.mgmt.compute import ComputeManagementClient
 client = get_client_from_cli_profile(ComputeManagementClient)
 ```
 
-### Authenticate with token credentials (legacy)
+## <a name="mgmt-auth-legacy"></a>Authenticate with token credentials (legacy)
 
-In previous version of the SDK, ADAL was not yet available and only `UserPassCredentials` and `ServicePrincipalCredentials` classes were available. This is considered deprecated and should not be used anymore (for instance, these classes have no support for 
-Germany or Government Azure).
+In previous version of the SDK, ADAL was not yet available and we provided a `UserPassCredentials` class. This is considered deprecated and should not be used anymore.
 
 This sample shows user/password scenario. This does not support 2FA.
 
@@ -91,17 +195,5 @@ This sample shows user/password scenario. This does not support 2FA.
     credentials = UserPassCredentials(
         'user@domain.com',
         'my_smart_password',
-    )
-```
-
-This sample shows Service Principal authentication.
-
-```python
-    from azure.common.credentials import ServicePrincipalCredentials
-
-    credentials = ServicePrincipalCredentials(
-        client_id = 'a2ab11af-01aa-4759-8345-7803287dbd39',
-        secret = 'password',
-        tenant = 'ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF'
     )
 ```


### PR DESCRIPTION
- Change the title level, so we get a usuable right column (today it's pointless)
- Move ServicePrincipalCredentials up to recommended and not deprecated (after discussion)
- Add `get_client_from_auth_file`

This integrates update in https://github.com/MicrosoftDocs/azure-docs-sdk-python/pull/74, to avoid too many unecessary conflict in the future.