### PR TITLE
demonstrate correct base_url

### DIFF
--- a/docs-ref-conceptual/python-sdk-azure-authenticate.md
+++ b/docs-ref-conceptual/python-sdk-azure-authenticate.md
@@ -118,7 +118,7 @@ client = ComputeManagementClient(credentials, subscription_id)
 > When using an Azure sovereign cloud you must also specify the appropriate base URL (via the constants in `msrestazure.azure_cloud`) when creating the management client. For example for Azure China Cloud:
 > ```python
 > client = ComputeManagementClient(credentials, subscription_id,
->     base_url=AZURE_CHINA_CLOUD.endpoints.active_directory_resource_id)
+>     base_url=AZURE_CHINA_CLOUD.endpoints.resource_manager)
 > ```
 
 


### PR DESCRIPTION
Fix base url for authentication to sovereign clouds.

This is in reference to a support incident I recently filed with Microsoft. The `<sov_cloud>.endpoints.resource_manager` is the appropriate `base_url` for all `*Client` objects in the SDK.