### PR TITLE
Docs recommended installing *wrong* library

### DIFF
--- a/docs-ref-services/servicebus.md
+++ b/docs-ref-services/servicebus.md
@@ -19,7 +19,7 @@ Microsoft Azure Service Bus supports a set of cloud-based, message-oriented midd
 
 ## Install the libraries
 ```bash
-pip install azure-mgmt-servicebus
+pip install azure-servicebus
 ```
 
 ## ServiceBus Queues


### PR DESCRIPTION
Actual dependency used in the code samples looks to be this one: https://github.com/Azure/azure-sdk-for-python/tree/master/azure-servicebus

Not this one: https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-servicebus

Installing the one recommended by the docs resulted in `ImportError` for me.