### PR TITLE
Add Resource Graph to mapping

### DIFF
--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -491,6 +491,7 @@
       - 'azure-mgmt-relay'
   - name: Resource Graph
     uid: azure.python.sdk.landingPage.services.Resource.Graph
+    landingPageType: Service
     items:
     - name: Management
       uid: azure.python.sdk.landingPage.services.Resource.Graph.Management

--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -489,6 +489,14 @@
       landingPageType: Service
       children:
       - 'azure-mgmt-relay'
+  - name: Resource Graph
+    uid: azure.python.sdk.landingPage.services.Resource.Graph
+    items:
+    - name: Management
+      uid: azure.python.sdk.landingPage.services.Resource.Graph.Management
+      landingPageType: Service
+      children:
+      - 'azure-mgmt-resourcegraph'
   - name: Resources
     uid: azure.python.sdk.landingPage.services.Resources
     href: ~/docs-ref-services/resources.md


### PR DESCRIPTION
First step to get Resource Graph added to the docs TOC for Python SDK.