### PR TITLE
BatchAI: Adding deprecation banner

### DIFF
--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -38,6 +38,7 @@
       - 'azure-mgmt-authorization*'
   - name: Batch AI
     uid: azure.python.sdk.landingPage.services.BatchAI
+    href: ~/docs-ref-services/batchai.md
     landingPageType: Service
     items:
     - name: Management

--- a/docs-ref-services/batchai.md
+++ b/docs-ref-services/batchai.md
@@ -1,0 +1,17 @@
+---
+title: Azure Batch AI libraries for Python
+description: Reference documentation for the Python client libraries for Azure Batch AI
+keywords: Azure, Python, SDK, API, SQL, database, PostGres,Cosmos DB, NoSQL 
+author: garyericson
+ms.author: garye
+manager: cjgronlun
+ms.date: 03/26/2019
+ms.topic: article
+ms.devlang: python
+ms.service: bacth-ai
+---
+
+# Azure Batch AI libraries for Python
+
+>[!Note]
+>**Azure Batch AI has been retired.** The capabilities of Azure Batch AI are now available as a managed compute target in Azure Machine Learning service. For more information, see [What happened to Batch AI?](https://aka.ms/batchai-retirement)


### PR DESCRIPTION
Azure Batch AI is deprecated, so we want to add a banner to the ref content explaining that.