### PR TITLE
[toc] Remove AML from reference.yml

### DIFF
--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -156,7 +156,7 @@
       uid: azure.python.sdk.landingPage.services.Cognitive.Services.Speech
       landingPageType: Service
       children:
-      - 'azure-cognitiveservices-speech*'      
+      - 'azure-cognitiveservices-speech*'
     - name: Spell Check
       uid: azure.python.sdk.landingPage.services.Cognitive.Services.Text.SpellCheck
       landingPageType: Service
@@ -399,15 +399,6 @@
       landingPageType: Service
       children:
       - 'azure-mgmt-logic*'
-  - name: Machine Learning
-    uid: azure.python.sdk.landingPage.services.Machine.Learning.Compute
-    landingPageType: Service
-    items:
-    - name: Management
-      uid: azure.python.sdk.landingPage.services.Machine.Learning.Compute.Management
-      landingPageType: Service
-      children:
-      - 'azure-mgmt-machinelearningcompute*'
   - name: Media Services
     uid: azure.python.sdk.landingPage.services.Media
     href: ~/docs-ref-services/media-services.md
@@ -525,7 +516,7 @@
     - name: Management
       uid: azure.python.sdk.landingPage.services.ResourceGraph.Management
       children:
-      - 'azure-mgmt-resourcegraph*'      
+      - 'azure-mgmt-resourcegraph*'
   - name: Scheduler
     uid: azure.python.sdk.landingPage.services.Scheduler
     href: ~/docs-ref-services/scheduler.md


### PR DESCRIPTION
Per @j-martens, the Machine Learning entry in the Azure Python SDK TOC can be removed as that content has been moved out of this repository.