### PR TITLE
Added missing imports to example

### DIFF
--- a/docs-ref-services/storage.md
+++ b/docs-ref-services/storage.md
@@ -41,7 +41,7 @@ pip install azure-mgmt-storage
 
 ## Example
 ```python
-from azure.storage.blob import BlockBlobService
+from azure.storage.blob import BlockBlobService, PublicAccess, ContentSettings
 
 blob_service = BlockBlobService(account_name, account_key)
 


### PR DESCRIPTION
To make the example work, `PublicAccess` and `ContentSettings` have to be imported as well, otherwise Python complains that they're unknown. Tripped on that :)