### PR TITLE
Schema Registry

### DIFF
--- a/docs-ref-mapping/reference-unified.yml
+++ b/docs-ref-mapping/reference-unified.yml
@@ -686,7 +686,7 @@
         - 'azure-schemaregistry'
       - name: Schema Registry Avro Serializer
         uid: azure.python.sdk.landingPage.services.SchemaRegistry.SyncSerializer.Avro
-        href: ~/docs-ref-services/schemaregistry-avroserializer-readme-pre.md
+        href: ~/docs-ref-services/schemaregistry-avroserializer-readme.md
         children:
         - 'azure-schemaregistry-avroserializer'
   - name: Search

--- a/docs-ref-mapping/reference-unified.yml
+++ b/docs-ref-mapping/reference-unified.yml
@@ -681,7 +681,7 @@
       items:
       - name: Schema Registry Client
         uid: azure.python.sdk.landingPage.services.SchemaRegistry.Client
-        href: ~/docs-ref-services/schemaregistry-readme-pre.md
+        href: ~/docs-ref-services/schemaregistry-readme.md
         children:
         - 'azure-schemaregistry'
       - name: Schema Registry Avro Serializer

--- a/docs-ref-mapping/reference-unified.yml
+++ b/docs-ref-mapping/reference-unified.yml
@@ -676,6 +676,19 @@
       landingPageType: Service
       children:
       - 'azure-mgmt-scheduler*'
+  - name: Schema Registry
+      uid: azure.python.sdk.landingPage.services.SchemaRegistry
+      items:
+      - name: Schema Registry Client
+        uid: azure.python.sdk.landingPage.services.SchemaRegistry.Client
+        href: ~/docs-ref-services/schemaregistry-readme-pre.md
+        children:
+        - 'azure-schemaregistry'
+      - name: Schema Registry Avro Serializer
+        uid: azure.python.sdk.landingPage.services.SchemaRegistry.SyncSerializer.Avro
+        href: ~/docs-ref-services/schemaregistry-avroserializer-readme-pre.md
+        children:
+        - 'azure-schemaregistry-avroserializer'
   - name: Search
     uid: azure.python.sdk.landingPage.services.Search
     href: ~/docs-ref-services/search.md


### PR DESCRIPTION
Questions:

1. do we need `href` under top level? that is:
```
  - name: Schema Registry
      uid: azure.python.sdk.landingPage.services.SchemaRegistry
      href: ~/docs-ref-services/schema-registry-index.md  # like storage or eh approach
```
answer: not for now, until we have manually written pages that describe SR service as a whole

2. If we need a `schema-registry-index.md`, what should be the content look like? storage, keyvault? (There are broken links in EH, we need to fix them)
  - shall we update our github repo, to let top-level dir have a readme like storage?
