### PR TITLE
fix bookmarks

### DIFF
--- a/docs-ref-services/storage-blob-readme-pre.md
+++ b/docs-ref-services/storage-blob-readme-pre.md
@@ -71,7 +71,7 @@ service = BlobServiceClient(account_url="https://<my-storage-account-name>.blob.
 You can find the storage account's blob service URL using the 
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the blob service account url for the storage account

--- a/docs-ref-services/storage-blob-readme.md
+++ b/docs-ref-services/storage-blob-readme.md
@@ -73,7 +73,7 @@ service = BlobServiceClient(account_url="https://<my-storage-account-name>.blob.
 You can find the storage account's blob service URL using the 
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the blob service account url for the storage account

--- a/docs-ref-services/storage-file-share-readme-pre.md
+++ b/docs-ref-services/storage-file-share-readme-pre.md
@@ -68,7 +68,7 @@ service = ShareServiceClient(account_url="https://<my-storage-account-name>.file
 You can find the storage account's file service URL using the
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the file service URL for the storage account

--- a/docs-ref-services/storage-file-share-readme.md
+++ b/docs-ref-services/storage-file-share-readme.md
@@ -70,7 +70,7 @@ service = ShareServiceClient(account_url="https://<my-storage-account-name>.file
 You can find the storage account's file service URL using the
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the file service URL for the storage account

--- a/docs-ref-services/storage-fileshare-readme.md
+++ b/docs-ref-services/storage-fileshare-readme.md
@@ -69,7 +69,7 @@ service = ShareServiceClient(account_url="https://<my-storage-account-name>.file
 You can find the storage account's file service URL using the
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the file service URL for the storage account

--- a/docs-ref-services/storage-queue-readme.md
+++ b/docs-ref-services/storage-queue-readme.md
@@ -70,7 +70,7 @@ service = QueueServiceClient(account_url="https://<my-storage-account-name>.queu
 You can find the storage account's queue service URL using the 
 [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-account-overview#storage-account-endpoints),
 [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.storage/get-azstorageaccount),
-or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az-storage-account-show):
+or [Azure CLI](https://docs.microsoft.com/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_show):
 
 ```bash
 # Get the queue service URL for the storage account


### PR DESCRIPTION
For AzureCLIGroups files, the bookmark are generated with `_` instead of `-`