### PR TITLE
Fix Synapse Mapping

### DIFF
--- a/docs-ref-mapping/reference-unified.yml
+++ b/docs-ref-mapping/reference-unified.yml
@@ -911,7 +911,7 @@
       uid: azure.python.sdk.landingPage.services.Synapse.Client
       landingPageType: Service
       children:
-      - 'azure-synapse-*'
+      - 'azure-synapse*'
   - name: Tables
     uid: azure.python.sdk.landingPage.services.Tables
     href: ~/docs-ref-services/data-tables-readme.md


### PR DESCRIPTION
`azure-synapse` was being excluded from the `Synapse` service due to ToC config only include `azure-synapse-` prefixed packages.