### PR TITLE
Try to resolve duplicate output files

### DIFF
--- a/docs-ref-mapping/reference-previous.yml
+++ b/docs-ref-mapping/reference-previous.yml
@@ -15,6 +15,7 @@
       - 'azure-eventhub*'
   - name: Service Bus
     uid: azure.python.sdk.landingPage.services.ServiceBus.Previous
+    href: ~/docs-ref-services/legacy/servicebus.md
     landingPageType: Service
     children:
       - 'azure-servicebus*'
@@ -27,6 +28,7 @@
       - 'azure-storage-common'
   - name: Other
     uid: azure.python.sdk.landingPage.services.other.Previous
+    href: ~/docs-ref-services/legacy/other.md
     landingPageType: Service
     children:
     - '*'


### PR DESCRIPTION
Below files will be published to same url, please help fix this issue by either adding `href` to TopLevelTocItem or removing/renaming the existing markdown files. 

| site url | existing markdown file | generated service page for TopLevelToc |
| --- | --- | --- |
| /python/api/overview/azure/servicebus | [docs-ref-services/legacy/servicebus.md](https://github.com/MicrosoftDocs/azure-docs-sdk-python/blob/master/docs-ref-services/legacy/servicebus.md) | [previous/docs-ref-autogen/overview/azure/ServiceBus.yml](https://github.com/MicrosoftDocs/azure-docs-sdk-python/blob/master/docs-ref-mapping/reference-previous.yml#L16-L17) |
| /python/api/overview/azure/other | [docs-ref-services/legacy/other.md](https://github.com/MicrosoftDocs/azure-docs-sdk-python/blob/master/docs-ref-services/legacy/other.md) | [previous/docs-ref-autogen/overview/azure/Other.yml](https://github.com/MicrosoftDocs/azure-docs-sdk-python/blob/master/docs-ref-mapping/reference-previous.yml#L28-L29) |