### PR TITLE
Remove br tags from documentation

### DIFF
--- a/docs-ref-autogen/azure-mgmt-compute/azure.mgmt.compute.v2020_09_30.models.GalleryImage.yml
+++ b/docs-ref-autogen/azure-mgmt-compute/azure.mgmt.compute.v2020_09_30.models.GalleryImage.yml
@@ -59,9 +59,7 @@ constructor:
     description: 'This property allows you to specify the type of the OS that is included
       in the
 
-      disk when creating a VM from a managed image. `<br>``<br>` Possible values are:
-
-      `<br>``<br>` **Windows** `<br>``<br>` **Linux**. Possible values
+      disk when creating a VM from a managed image. Possible values
 
       include: "Windows", "Linux".'
     types:


### PR DESCRIPTION
break tags are shown on the site for OS type - https://docs.microsoft.com/en-us/python/api/azure-mgmt-compute/azure.mgmt.compute.v2020_09_30.models.galleryimage?view=azure-python

Removing these