### PR TITLE
Fix service page generation

### DIFF
--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -579,10 +579,10 @@
   - name: Monitoring
     uid: azure.python.sdk.landingPage.services.Monitor
     landingPageType: Service
+    href: ~/docs-ref-services/latest/monitoring.md
     items:
     - name: Management
       uid: azure.python.sdk.landingPage.services.Monitor.Management
-      href: ~/docs-ref-services/latest/monitoring.md
       children:
       - azure-mgmt-monitor*
   - name: NetApp


### PR DESCRIPTION
`~/docs-ref-services/latest/monitoring.md` shares the same publish URL with generated service page for monitoring.
This .md file should be used instead of the generated service page.

And this publish URL conflicts is causing publish failure.