### PR TITLE
Remove Duplicate `azure-mgmt-servicebus`

### DIFF
--- a/ci-configs/packages-latest.json
+++ b/ci-configs/packages-latest.json
@@ -887,18 +887,6 @@
     },
     {
       "package_info": {
-        "install_type": "dist_file",
-        "location": "https://docsupport.blob.core.windows.net/repackaged/azure-mgmt-servicebus-6.0.0.tar.gz"
-      },
-      "exclude_path": [
-        "test*",
-        "example*",
-        "sample*",
-        "doc*"
-      ]
-    },
-    {
-      "package_info": {
         "url": "https://github.com/Azure/azure-sdk-for-python.git",
         "branch": "master",
         "folder": "azure-mgmt-servicefabric",


### PR DESCRIPTION
We had a patched version in there to repair the original `mgmt-servicebus 6.0.0`. It's been resolved in further releases, so just leaving the `pypi` one there.