### PR TITLE
Update topic type to managed-reference

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -196,9 +196,9 @@
         "docs-ref-services/**/*.md": "tracking-python"
       },
       "ms.topic": {
-        "docs-ref-autogen/**/*.yml": "reference",
-        "preview/docs-ref-autogen/**/*.yml": "reference",
-        "previous/docs-ref-autogen/**/*.yml": "reference"
+        "docs-ref-autogen/**/*.yml": "managed-reference",
+        "preview/docs-ref-autogen/**/*.yml": "managed-reference",
+        "previous/docs-ref-autogen/**/*.yml": "managed-reference"
       },
       "msservice": {
         "docs-ref-autogen/**/adal**.yml": "active-directory",


### PR DESCRIPTION
Autogenerated reference topics are supposed to be 'managed-reference' as opposed to reference.  Updating docfx to reflect this.