### PR TITLE
Fixing wrong endpoint url scanning.azure.com

### DIFF
--- a/docs-ref-services/preview/purview-scanning-readme.md
+++ b/docs-ref-services/preview/purview-scanning-readme.md
@@ -66,7 +66,7 @@ from azure.purview.scanning import PurviewScanningClient
 from azure.identity import DefaultAzureCredential
 
 credential = DefaultAzureCredential()
-client = PurviewScanningClient(endpoint="https://<my-account-name>.scanning.purview.azure.com", credential=credential)
+client = PurviewScanningClient(endpoint="https://<my-account-name>.scan.purview.azure.com", credential=credential)
 ```
 
 ## Key concepts
@@ -91,7 +91,7 @@ from azure.purview.scanning.rest import data_sources
 from azure.core.exceptions import HttpResponseError
 
 credential = DefaultAzureCredential()
-client = PurviewScanningClient(endpoint="https://<my-account-name>.scanning.purview.azure.com", credential=credential)
+client = PurviewScanningClient(endpoint="https://<my-account-name>.scan.purview.azure.com", credential=credential)
 
 request = data_sources.build_list_all_request()
 
@@ -138,7 +138,7 @@ logger.setLevel(logging.DEBUG)
 handler = logging.StreamHandler(stream=sys.stdout)
 logger.addHandler(handler)
 
-endpoint = "https://<my-account-name>.scanning.purview.azure.com"
+endpoint = "https://<my-account-name>.scan.purview.azure.com"
 credential = DefaultAzureCredential()
 
 # This client will log detailed information about its HTTP sessions, at DEBUG level


### PR DESCRIPTION
The correct url needs to be changed from `.scanning.purview.azure.com` to `.scan.purview.azure.com`.
Reference: https://docs.microsoft.com/en-us/rest/api/purview/scanningdataplane/scans/get