### PR TITLE
1876839: Add CLI contributor role to code blocks

### DIFF
--- a/docs-ref-services/latest/containerinstance.md
+++ b/docs-ref-services/latest/containerinstance.md
@@ -40,7 +40,9 @@ One of the easiest ways to authenticate SDK clients (like the Azure Container In
 
 1. Create a credentials file with the [Azure CLI](/cli/azure) or [Cloud Shell](https://shell.azure.com/):
 
-   `az ad sp create-for-rbac --sdk-auth > my.azureauth`
+   ```azurecli
+   az ad sp create-for-rbac --role Contributor --sdk-auth > my.azureauth
+   ```
 
    If you use the [Cloud Shell](https://shell.azure.com/) to generate the credentials file, copy its contents into a local file that your Python application can access.
 

--- a/docs-ref-services/latest/containerinstance.md
+++ b/docs-ref-services/latest/containerinstance.md
@@ -8,7 +8,6 @@ manager: jeconnoc
 ms.date: 04/15/2019
 ms.author: danlep
 ms.topic: reference
-ms.technology: azure
 ms.devlang: python
 ms.service: container-instances
 ---

--- a/docs-ref-services/latest/containerinstance.md
+++ b/docs-ref-services/latest/containerinstance.md
@@ -8,7 +8,6 @@ manager: jeconnoc
 ms.date: 04/15/2019
 ms.author: danlep
 ms.topic: reference
-ms.prod: azure
 ms.technology: azure
 ms.devlang: python
 ms.service: container-instances

--- a/docs-ref-services/latest/hdinsight.md
+++ b/docs-ref-services/latest/hdinsight.md
@@ -74,7 +74,7 @@ az account set -s <name or ID of subscription>
 Next, choose a name for your service principal and create it with the following command:
 
 ```azurecli-interactive
-az ad sp create-for-rbac --name <Service Principal Name> --sdk-auth
+az ad sp create-for-rbac --name <Service Principal Name> --role Contributor --sdk-auth
 ```
 
 The service principal information is displayed as JSON.

--- a/docs-ref-services/legacy/containerinstance.md
+++ b/docs-ref-services/legacy/containerinstance.md
@@ -40,7 +40,9 @@ One of the easiest ways to authenticate SDK clients (like the Azure Container In
 
 1. Create a credentials file with the [Azure CLI](/cli/azure) or [Cloud Shell](https://shell.azure.com/):
 
-   `az ad sp create-for-rbac --sdk-auth > my.azureauth`
+   ```azurecli
+   az ad sp create-for-rbac --role Contributor --sdk-auth > my.azureauth
+   ```
 
    If you use the [Cloud Shell](https://shell.azure.com/) to generate the credentials file, copy its contents into a local file that your Python application can access.
 

--- a/docs-ref-services/legacy/containerinstance.md
+++ b/docs-ref-services/legacy/containerinstance.md
@@ -8,7 +8,6 @@ manager: jeconnoc
 ms.date: 04/15/2019
 ms.author: danlep
 ms.topic: reference
-ms.technology: azure
 ms.devlang: python
 ms.service: container-instances
 ---

--- a/docs-ref-services/legacy/containerinstance.md
+++ b/docs-ref-services/legacy/containerinstance.md
@@ -8,7 +8,6 @@ manager: jeconnoc
 ms.date: 04/15/2019
 ms.author: danlep
 ms.topic: reference
-ms.prod: azure
 ms.technology: azure
 ms.devlang: python
 ms.service: container-instances

--- a/docs-ref-services/legacy/hdinsight.md
+++ b/docs-ref-services/legacy/hdinsight.md
@@ -74,7 +74,7 @@ az account set -s <name or ID of subscription>
 Next, choose a name for your service principal and create it with the following command:
 
 ```azurecli-interactive
-az ad sp create-for-rbac --name <Service Principal Name> --sdk-auth
+az ad sp create-for-rbac --name <Service Principal Name> --role Contributor --sdk-auth
 ```
 
 The service principal information is displayed as JSON.

--- a/docs-ref-services/preview/containerinstance.md
+++ b/docs-ref-services/preview/containerinstance.md
@@ -40,7 +40,9 @@ One of the easiest ways to authenticate SDK clients (like the Azure Container In
 
 1. Create a credentials file with the [Azure CLI](/cli/azure) or [Cloud Shell](https://shell.azure.com/):
 
-   `az ad sp create-for-rbac --sdk-auth > my.azureauth`
+   ```azurecli
+   az ad sp create-for-rbac --role Contributor --sdk-auth > my.azureauth
+   ```
 
    If you use the [Cloud Shell](https://shell.azure.com/) to generate the credentials file, copy its contents into a local file that your Python application can access.
 

--- a/docs-ref-services/preview/containerinstance.md
+++ b/docs-ref-services/preview/containerinstance.md
@@ -8,7 +8,6 @@ manager: jeconnoc
 ms.date: 04/15/2019
 ms.author: danlep
 ms.topic: reference
-ms.technology: azure
 ms.devlang: python
 ms.service: container-instances
 ---

--- a/docs-ref-services/preview/containerinstance.md
+++ b/docs-ref-services/preview/containerinstance.md
@@ -8,7 +8,6 @@ manager: jeconnoc
 ms.date: 04/15/2019
 ms.author: danlep
 ms.topic: reference
-ms.prod: azure
 ms.technology: azure
 ms.devlang: python
 ms.service: container-instances

--- a/docs-ref-services/preview/hdinsight.md
+++ b/docs-ref-services/preview/hdinsight.md
@@ -74,7 +74,7 @@ az account set -s <name or ID of subscription>
 Next, choose a name for your service principal and create it with the following command:
 
 ```azurecli-interactive
-az ad sp create-for-rbac --name <Service Principal Name> --sdk-auth
+az ad sp create-for-rbac --name <Service Principal Name> --role Contributor --sdk-auth
 ```
 
 The service principal information is displayed as JSON.


### PR DESCRIPTION
Default role: Contributor is being deprecated for az ad sp create-for-rbac. Added --role contributor to code blocks where the current role selection is left as default (no parameter). Added CLI code block tags where missing in containerinstance files.

User story [1876839](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1876839)