### PR TITLE
Reorganize Monitor APIs in ToC

### DIFF
--- a/docs-ref-mapping/reference-unified.yml
+++ b/docs-ref-mapping/reference-unified.yml
@@ -673,20 +673,20 @@
       landingPageType: Service
       children:
       - 'azure-mgmt-mixedreality*'
-  - name: Monitor Query
-    uid: azure.python.sdk.landingPage.services.MonitorQuery
-    href: ~/docs-ref-services/{moniker}/monitor-query-readme.md
-    children:
-    - azure-monitor-query*
-  - name: Monitoring
+  - name: Monitor
     uid: azure.python.sdk.landingPage.services.Monitor
     landingPageType: Service
     items:
-    - name: Client
+    - name: OpenTelemetry Exporter
       uid: azure.python.sdk.landingPage.services.Monitor.Client
       href: ~/docs-ref-services/{moniker}/opentelemetry-exporter-azuremonitor-readme.md
       children:
       - opentelemetry-exporter-azuremonitor*
+    - name: Query
+      uid: azure.python.sdk.landingPage.services.MonitorQuery
+      href: ~/docs-ref-services/{moniker}/monitor-query-readme.md
+      children:
+      - azure-monitor-query*
     - name: Management
       uid: azure.python.sdk.landingPage.services.Monitor.Management
       href: ~/docs-ref-services/{moniker}/mgmt-monitor.md


### PR DESCRIPTION
**Summary of changes**

- Rename "Monitoring" ToC node to "Monitor"
- Rename "Client" ToC node to "OpenTelemetry Exporter"
- Move Monitor Query APIs to the "Monitor" ToC node