### PR TITLE
(AzureCXP) fixes Azure/azure-sdk-for-python#24169

### DIFF
--- a/docs-ref-services/latest/compute.md
+++ b/docs-ref-services/latest/compute.md
@@ -67,7 +67,7 @@ def create_vm()
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the Management APIs](/python/api/overview/azure/virtualmachines/management)
+> [Explore the Management APIs](/python/api/azure-mgmt-compute/azure.mgmt.compute)
 
 ## Samples
 


### PR DESCRIPTION
The Explore the Management APIs button links to a 404.

Old Link: /python/api/overview/azure/virtualmachines/management
New Link: /python/api/azure-mgmt-compute/azure.mgmt.compute