### PR TITLE
{LogicApp} Fixes Azure/azure-sdk-for-python#24662

### DIFF
--- a/docs-ref-services/latest/logic-apps.md
+++ b/docs-ref-services/latest/logic-apps.md
@@ -25,4 +25,4 @@ ms.service: multiple
 pip install azure-mgmt-logic
 ```
 > [!div class="nextstepaction"]
-> [Explore the Management APIs](/python/api/overview/azure/logicapps/management)
+> [Explore the Management APIs](/python/api/azure-mgmt-logic)


### PR DESCRIPTION
The Explore Management APIs button is redirecting to an incorrect link.

Old Link: https://docs.microsoft.com/en-us/python/api/overview/azure/logicapps/management
New Link: https://docs.microsoft.com/en-us/python/api/azure-mgmt-logic

Fixes Azure/azure-sdk-for-python#24662