### PR TITLE
Update azure.storage.filedatalake.FileSystemClient.yml

### DIFF
--- a/docs-ref-autogen/azure-storage-file-datalake/azure.storage.filedatalake.FileSystemClient.yml
+++ b/docs-ref-autogen/azure-storage-file-datalake/azure.storage.filedatalake.FileSystemClient.yml
@@ -939,10 +939,10 @@ methods:
   - name: max_results
     description: 'An optional value that specifies the maximum
 
-      number of items to return per page. If omitted or greater than 5,000, the
+      number of items to return per page. If omitted, the
 
       response will include up to 5,000 items per page.'
-    defaultValue: 'True'
+    defaultValue: None
     types:
     - <xref:int>
   - name: upn


### PR DESCRIPTION
Fix description of `get_results`. Since [this PR](https://github.com/Azure/azure-sdk-for-python/pull/16581) the limit is no longer just 5000 items.