### PR TITLE
{AzureIoT} fixes Azure/azure-sdk-for-python#27252 update description

### DIFF
--- a/docs-ref-autogen/azure-iot-hub/azure.iot.hub.IoTHubRegistryManager.yml
+++ b/docs-ref-autogen/azure-iot-hub/azure.iot.hub.IoTHubRegistryManager.yml
@@ -98,7 +98,7 @@ methods:
   - type: <xref:if the HTTP response status is not in >[<xref:200>]<xref:.>
 - uid: azure.iot.hub.IoTHubRegistryManager.create_device_with_sas
   name: create_device_with_sas
-  summary: Creates a device identity on IoTHub using SAS authentication.
+  summary: Creates a device identity on IoTHub that will use SAS as authentication method.
   signature: create_device_with_sas(device_id, primary_key, secondary_key, status,
     iot_edge=False, status_reason=None, device_scope=None, parent_scopes=None)
   parameters:


### PR DESCRIPTION
fixes Azure/azure-sdk-for-python#27252

PR to update the description for create_device_with_sas method to "Creates a device identity on IoTHub that will use SAS as authentication method."