### PR TITLE
{AzureIoT} fixes Azure/azure-sdk-for-python#28891 Updating the function name

### DIFF
--- a/docs-ref-services/latest/iot.md
+++ b/docs-ref-services/latest/iot.md
@@ -46,7 +46,7 @@ iothub_client = IotHubClient(
 
 ## Create an IoTHub
 ```python
-async_iot_hub = iothub_client.iot_hub_resource.create_or_update(
+async_iot_hub = iothub_client.iot_hub_resource.begin_create_or_update(
     'MyResourceGroup',
     'MyIoTHubAccount',
     {


### PR DESCRIPTION
This issue fixes the function name of IoTHub Client
fixes Azure/azure-sdk-for-python#28891 
