### PR TITLE
{AzureIOT} Fix the broken Management API link for IOT package

### DIFF
--- a/docs-ref-services/latest/iot.md
+++ b/docs-ref-services/latest/iot.md
@@ -75,4 +75,4 @@ iothub = async_iot_hub.result() # Blocking wait for creation
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the Management APIs](/python/api/overview/azure/iot/management)
+> [Explore the Management APIs](/python/api/overview/azure/mgmt-iothub-readme)

--- a/docs-ref-services/legacy/iot.md
+++ b/docs-ref-services/legacy/iot.md
@@ -81,4 +81,4 @@ iothub = async_iot_hub.result() # Blocking wait for creation
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the Management APIs](/python/api/overview/azure/iot/management)
+> [Explore the Management APIs](/python/api/overview/azure/mgmt-iothub-readme)

--- a/docs-ref-services/preview/iot.md
+++ b/docs-ref-services/preview/iot.md
@@ -75,4 +75,4 @@ iothub = async_iot_hub.result() # Blocking wait for creation
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the Management APIs](/python/api/overview/azure/iot/management)
+> [Explore the Management APIs](/python/api/overview/azure/mgmt-iothub-readme)


### PR DESCRIPTION
The management API link is incorrect. It currently leads to 404 error.

Old Link: /python/api/overview/azure/iot/management
New Link: /python/api/overview/azure/mgmt-iothub-readme

 fixes Azure/azure-sdk-for-python#29309