### PR TITLE
Update docs CI Config

### DIFF
--- a/ci-configs/packages-latest.json
+++ b/ci-configs/packages-latest.json
@@ -14,7 +14,7 @@
         "version": "==13.0.0"
       },
       "exclude_path": [
-        "test*",
+        "test*",z
         "example*",
         "sample*",
         "doc*"
@@ -1146,8 +1146,8 @@
     },
     {
       "package_info": {
-        "install_type": "dist_file",
-        "location": "https://docsupport.blob.core.windows.net/repackaged/azure-functions-1.4.0.tar.gz"
+        "install_type": "pypi",
+        "name": "azure-functions"
       },
       "exclude_path": [
         "test*",

--- a/ci-configs/packages-latest.json
+++ b/ci-configs/packages-latest.json
@@ -14,7 +14,7 @@
         "version": "==13.0.0"
       },
       "exclude_path": [
-        "test*",z
+        "test*",
         "example*",
         "sample*",
         "doc*"


### PR DESCRIPTION
Azure-functions version update in packages-latest.json

The original package being loaded was _azure-fucntions_ **1.4.0** release on Oct 2020 which is absolutely not the latest.The latest package should be **1.13.3** released on March 2023.
In this change, I make it use pip to install azure-fucntions so that it always load the latest package.