### PR TITLE
Please elaborate the following "The Blob service copies blobs on a best-effort basis"

### DIFF
--- a/docs-ref-autogen/azure-storage-blob/azure.storage.blob.BlobClient.yml
+++ b/docs-ref-autogen/azure-storage-blob/azure.storage.blob.BlobClient.yml
@@ -3517,7 +3517,7 @@ methods:
     checking the copy status. Set *requires_sync* to True to force the copy to be
     synchronous.
 
-    The Blob service copies blobs on a best-effort basis.
+    Due to the asynchronous nature of the copy operation, Blob Storage copies blobs on a best-effort basis. The Blob service copies blobs when server resources are not being utilized by other tasks, so a copy is not guaranteed to start immediately or complete in a specified timeframe.
 
 
     The source blob for a copy operation may be a block blob, an append blob,


### PR DESCRIPTION
…st-effort basis."

We got the master article changed recently with more details.  "https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob?tabs=azure-ad#remarks" 

Earlier the article said "The Blob service copies blobs on a best-effort basis" but now it has been updated to say "Due to the asynchronous nature of the copy operation, Blob Storage copies blobs on a best-effort basis. The Blob service copies blobs when server resources are not being utilized by other tasks, so a copy is not guaranteed to start immediately or complete in a specified timeframe." 

It would be great to update this article to be in sync with the other one.