### PR TITLE
Disable edit button on learn.microsoft.com for Python

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -10,7 +10,7 @@
         "azure-python-preview",
         "azure-python-previous"
       ],
-      "open_to_public_contributors": true,
+      "open_to_public_contributors": false,
       "type_mapping": {
         "Conceptual": "Content",
         "ManagedReference": "Content",


### PR DESCRIPTION
open_to_public_contributors was set to true which allows edits, set to false to disable.

Fixes: https://github.com/Azure/azure-sdk-for-python/issues/29671