### PR TITLE
Pull azure-functions and azure-functions-durable from PyPI

### DIFF
--- a/ci-configs/packages-latest.json
+++ b/ci-configs/packages-latest.json
@@ -1146,8 +1146,8 @@
     },
     {
       "package_info": {
-        "install_type": "dist_file",
-        "location": "https://docsupport.blob.core.windows.net/repackaged/azure-functions-1.4.0.tar.gz"
+        "install_type": "pypi",
+        "name": "azure-functions"
       },
       "exclude_path": [
         "test*",
@@ -1844,8 +1844,8 @@
     },
     {
       "package_info": {
-        "install_type": "dist_file",
-        "location": "https://docsupport.blob.core.windows.net/repackaged/azure-functions-durable-1.0.0b11.dev0%2Bg0b805d8.d20201106.tar.gz"
+        "install_type": "pypi",
+        "name": "azure-functions-durable"
       },
       "exclude_path": [
         "test*",


### PR DESCRIPTION
Currently, `azure-functions` and `azure-functions-durable` have out of date auto-generated docs. This appears to be due to the code source being on blob storage, instead of pulling from PyPI.

This PR aims to change this behavior so that the source code for these packages is pulled directly from the latest release on PyPI

@danieljurek, @gavin-aguiar 