### PR TITLE
Readd azure-iot-device, omitting the "prefer_source_distribution" entry. We need a way to know the right value to provide here going forward.

### DIFF
--- a/ci-configs/packages-preview.json
+++ b/ci-configs/packages-preview.json
@@ -3443,6 +3443,19 @@
         "sample*",
         "doc*"
       ]
+    },
+    {
+      "package_info": {
+        "name": "azure-iot-device",
+        "install_type": "pypi",
+        "version": "==3.0.0b2"
+      },
+      "exclude_path": [
+        "test*",
+        "example*",
+        "sample*",
+        "doc*"
+      ]
     }
   ],
   "required_packages": [


### PR DESCRIPTION
Example successful build: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=364533&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=1e77462e-7711-551f-cf20-c31b880b493a -- note "preview" had no `prefer_source_distribution` entry (latest does, and it failed) 