### PR TITLE
Rename client to email_client so that send examples work

### DIFF
--- a/docs-ref-services/latest/communication-email-readme.md
+++ b/docs-ref-services/latest/communication-email-readme.md
@@ -45,7 +45,7 @@ Email clients can be authenticated using the connection string acquired from an 
 from azure.communication.email import EmailClient
 
 connection_string = "endpoint=https://<resource-name>.communication.azure.com/;accessKey=<Base64-Encoded-Key>"
-client = EmailClient.from_connection_string(connection_string);
+email_client = EmailClient.from_connection_string(connection_string);
 ```
 
 Alternatively, you can also use Active Directory authentication using DefaultAzureCredential.
@@ -56,7 +56,7 @@ from azure.identity import DefaultAzureCredential
 
 # To use Azure Active Directory Authentication (DefaultAzureCredential) make sure to have AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET as env variables.
 endpoint = "https://<resource-name>.communication.azure.com"
-client = EmailClient(endpoint, DefaultAzureCredential())
+email_client = EmailClient(endpoint, DefaultAzureCredential())
 ```
 
 Email clients can also be authenticated using an [AzureKeyCredential][azure-key-credential].
@@ -67,7 +67,7 @@ from azure.core.credentials import AzureKeyCredential
 
 credential = AzureKeyCredential("<api_key>")
 endpoint = "https://<resource-name>.communication.azure.com/"
-client = EmailClient(endpoint, credential);
+email_client = EmailClient(endpoint, credential);
 ```
 
 ### Send an Email Message


### PR DESCRIPTION
The naming of the client and email_client are different between the authentication examples at the top and the send examples at the bottom, without this change the full example fails.