### PR TITLE
Fix breadcrumbs

### DIFF
--- a/bread/toc.yml
+++ b/bread/toc.yml
@@ -1,7 +1,3 @@
-- name: Docs
-  href: /
-  homepage: /
-  items:
-  - name: Azure for Python Developers
-    tocHref: /python/azure/
-    topicHref: /python/azure/index
+- name: Azure
+  tocHref: /python/azure/
+  topicHref: /azure/index

--- a/docfx.json
+++ b/docfx.json
@@ -153,7 +153,7 @@
       "feedback_system": "GitHub",
       "feedback_github_repo": "Azure/azure-sdk-for-python",
       "feedback_product_url": "https://github.com/Azure/azure-sdk-for-python/issues",
-      "breadcrumb_path": "/python/azure/bread/toc.json",
+      "breadcrumb_path": "/python/bread/toc.json",
       "apiPlatform": "python",
       "brand": "azure",
       "searchScope": [


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 