### PR TITLE
Onboard azureml-featurestore to doc gen

### DIFF
--- a/metadata/preview/azureml-featurestore.json
+++ b/metadata/preview/azureml-featurestore.json
@@ -2,6 +2,7 @@
   "Name": "azureml-featurestore",
   "Version": "0.1.0b6",
   "DevVersion": null,
+  "DirectoryPath": "",
   "ServiceDirectory": "NA",
   "Group": null,
   "SdkType": "client",

--- a/metadata/preview/azureml-featurestore.json
+++ b/metadata/preview/azureml-featurestore.json
@@ -1,0 +1,11 @@
+{
+  "Name": "azureml-featurestore",
+  "Version": "0.1.0b6",
+  "DevVersion": null,
+  "ServiceDirectory": "NA",
+  "Group": null,
+  "SdkType": "client",
+  "IsNewSdk": true,
+  "ArtifactName": "azureml-featurestore",
+  "ReleaseStatus": "2023-11-01"
+}


### PR DESCRIPTION
Onboard azureml-featurestore package, which is not published via azure-sdk pipeline.

Related PR: https://github.com/Azure/azure-sdk/pull/6914