### PR TITLE
Update docs metadata for release of `azure-keyvault-secrets`

### DIFF
--- a/docs-ref-services/latest/keyvault-secrets-readme.md
+++ b/docs-ref-services/latest/keyvault-secrets-readme.md
@@ -1,12 +1,12 @@
 ---
 title: Azure Key Vault Secrets client library for Python
 keywords: Azure, python, SDK, API, azure-keyvault-secrets, keyvault
-ms.date: 03/16/2023
+ms.date: 02/23/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: keyvault
 ---
-# Azure Key Vault Secrets client library for Python - version 4.7.0 
+# Azure Key Vault Secrets client library for Python - version 4.8.0 
 
 Azure Key Vault helps solve the following problems:
 
@@ -14,12 +14,12 @@ Azure Key Vault helps solve the following problems:
 securely store and control access to tokens, passwords, certificates, API keys,
 and other secrets
 - Cryptographic key management
-([azure-keyvault-keys](https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-keys)) -
+([azure-keyvault-keys](https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-keys)) -
 create, store, and control access to the keys used to encrypt your data
 - Certificate management
-([azure-keyvault-certificates](https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-certificates)) -
+([azure-keyvault-certificates](https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-certificates)) -
 create, manage, and deploy public and private SSL/TLS certificates
-- Vault administration ([azure-keyvault-administration](https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-administration)) - role-based access control (RBAC), and vault-level backup and restore options
+- Vault administration ([azure-keyvault-administration](https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-administration)) - role-based access control (RBAC), and vault-level backup and restore options
 
 [Source code][library_src]
 | [Package (PyPI)][pypi_package_secrets]
@@ -31,7 +31,7 @@ create, manage, and deploy public and private SSL/TLS certificates
 ## _Disclaimer_
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_.
-_Python 3.7 or later is required to use this package. For more details, please refer to [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy)._
+_Python 3.8 or later is required to use this package. For more details, please refer to [Azure SDK for Python version support policy](https://github.com/Azure/azure-sdk-for-python/wiki/Azure-SDKs-Python-version-support-policy)._
 
 ## Getting started
 ### Install packages
@@ -45,7 +45,7 @@ authentication as demonstrated below.
 
 ### Prerequisites
 * An [Azure subscription][azure_sub]
-* Python 3.7 or later
+* Python 3.8 or later
 * An existing [Azure Key Vault][azure_keyvault]. If you need to create one, you can do so using the Azure CLI by following the steps in [this document][azure_keyvault_cli].
 
 ### Authenticate the client
@@ -74,7 +74,7 @@ A secret consists of a secret value and its associated metadata and management
 information. This library handles secret values as strings, but Azure Key Vault
 doesn't store them as such. For more information about secrets and how Key
 Vault stores and manages them, see the
-[Key Vault documentation](/azure/key-vault/general/about-keys-secrets-certificates).
+[Key Vault documentation](https://docs.microsoft.com/azure/key-vault/general/about-keys-secrets-certificates).
 
 [SecretClient][secret_client_docs] can set secret values in the vault, update
 secret metadata, and delete secrets, as shown in the
@@ -195,7 +195,7 @@ for secret_property in secret_properties:
 This library includes a complete set of async APIs. To use them, you must
 first install an async transport, such as [aiohttp](https://pypi.org/project/aiohttp/).
 See
-[azure-core documentation](https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md#transport)
+[azure-core documentation](https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md#transport)
 for more information.
 
 Async clients and credentials should be closed when they're no longer needed. These
@@ -258,7 +258,7 @@ async for secret_property in secret_properties:
 ## Troubleshooting
 
 See the `azure-keyvault-secrets`
-[troubleshooting guide](https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/TROUBLESHOOTING.md)
+[troubleshooting guide](https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/TROUBLESHOOTING.md)
 for details on how to diagnose various failure scenarios.
 
 ### General
@@ -322,12 +322,11 @@ secret_client.get_secret("my-secret", logging_enable=True)
 ## Next steps
 Several samples are available in the Azure SDK for Python GitHub repository.
 These provide example code for additional Key Vault scenarios:
-| File | Description |
-|-------------|-------------|
-| [hello_world.py][hello_world_sample] ([async version][hello_world_async_sample]) | create/get/update/delete secrets |
-| [list_operations.py][list_operations_sample] ([async version][list_operations_async_sample]) | basic list operations for secrets |
-| [backup_restore_operations.py][backup_operations_sample] ([async version][backup_operations_async_sample]) | back up and restore secrets |
-| [recover_purge_operations.py][recover_purge_sample] ([async version][recover_purge_async_sample]) | recover and purge secrets |
+
+- [Create/get/update/delete secrets][hello_world_sample] ([async version][hello_world_async_sample])
+- [Basic list operations for secrets][list_operations_sample] ([async version][list_operations_async_sample])
+- [Back up and restore secrets][backup_operations_sample] ([async version][backup_operations_async_sample])
+- [Recover and purge secrets][recover_purge_sample] ([async version][recover_purge_async_sample])
 
 ###  Additional Documentation
 For more extensive documentation on Azure Key Vault, see the
@@ -352,39 +351,39 @@ contact opencode@microsoft.com with any additional questions or comments.
 
 <!-- LINKS -->
 [azure_cloud_shell]: https://shell.azure.com/bash
-[azure_core_exceptions]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.7.0/sdk/core/azure-core#azure-core-library-exceptions
-[azure_identity]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.7.0/sdk/identity/azure-identity
+[azure_core_exceptions]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/core/azure-core#azure-core-library-exceptions
+[azure_identity]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/identity/azure-identity
 [azure_identity_pypi]: https://pypi.org/project/azure-identity/
-[azure_keyvault]: /azure/key-vault/general/overview
-[azure_keyvault_cli]: /azure/key-vault/general/quick-create-cli
+[azure_keyvault]: https://docs.microsoft.com/azure/key-vault/general/overview
+[azure_keyvault_cli]: https://docs.microsoft.com/azure/key-vault/general/quick-create-cli
 [azure_sub]: https://azure.microsoft.com/free/
 
-[backup_operations_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations.py
-[backup_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations_async.py
+[backup_operations_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations.py
+[backup_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations_async.py
 
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 
 [default_cred_ref]: https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
 
-[hello_world_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
-[hello_world_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
+[hello_world_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
+[hello_world_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
 
-[library_src]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets
-[list_operations_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
-[list_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
+[library_src]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets
+[list_operations_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
+[list_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
 
-[managed_identity]: /azure/active-directory/managed-identities-azure-resources/overview
+[managed_identity]: https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
 
 [pip]: https://pypi.org/project/pip/
 [pypi_package_secrets]: https://pypi.org/project/azure-keyvault-secrets/
 
-[recover_purge_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations.py
-[recover_purge_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations_async.py
+[recover_purge_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations.py
+[recover_purge_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations_async.py
 [reference_docs]: https://aka.ms/azsdk/python/keyvault-secrets/docs
 
 [secret_client_docs]: https://aka.ms/azsdk/python/keyvault-secrets/docs#azure.keyvault.secrets.SecretClient
-[secret_samples]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.7.0/sdk/keyvault/azure-keyvault-secrets/samples
-[soft_delete]: /azure/key-vault/general/soft-delete-overview
+[secret_samples]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples
+[soft_delete]: https://docs.microsoft.com/azure/key-vault/general/soft-delete-overview
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-python%2Fsdk%2Fkeyvault%2Fazure-keyvault-secrets%2FREADME.png)
 

--- a/docs-ref-services/latest/keyvault-secrets-readme.md
+++ b/docs-ref-services/latest/keyvault-secrets-readme.md
@@ -74,7 +74,7 @@ A secret consists of a secret value and its associated metadata and management
 information. This library handles secret values as strings, but Azure Key Vault
 doesn't store them as such. For more information about secrets and how Key
 Vault stores and manages them, see the
-[Key Vault documentation](https://docs.microsoft.com/azure/key-vault/general/about-keys-secrets-certificates).
+[Key Vault documentation](/azure/key-vault/general/about-keys-secrets-certificates).
 
 [SecretClient][secret_client_docs] can set secret values in the vault, update
 secret metadata, and delete secrets, as shown in the
@@ -354,8 +354,8 @@ contact opencode@microsoft.com with any additional questions or comments.
 [azure_core_exceptions]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/core/azure-core#azure-core-library-exceptions
 [azure_identity]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/identity/azure-identity
 [azure_identity_pypi]: https://pypi.org/project/azure-identity/
-[azure_keyvault]: https://docs.microsoft.com/azure/key-vault/general/overview
-[azure_keyvault_cli]: https://docs.microsoft.com/azure/key-vault/general/quick-create-cli
+[azure_keyvault]: /azure/key-vault/general/overview
+[azure_keyvault_cli]: /azure/key-vault/general/quick-create-cli
 [azure_sub]: https://azure.microsoft.com/free/
 
 [backup_operations_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations.py
@@ -372,7 +372,7 @@ contact opencode@microsoft.com with any additional questions or comments.
 [list_operations_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
 [list_operations_async_sample]: https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
 
-[managed_identity]: https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
+[managed_identity]: /azure/active-directory/managed-identities-azure-resources/overview
 
 [pip]: https://pypi.org/project/pip/
 [pypi_package_secrets]: https://pypi.org/project/azure-keyvault-secrets/
@@ -383,7 +383,7 @@ contact opencode@microsoft.com with any additional questions or comments.
 
 [secret_client_docs]: https://aka.ms/azsdk/python/keyvault-secrets/docs#azure.keyvault.secrets.SecretClient
 [secret_samples]: https://github.com/Azure/azure-sdk-for-python/tree/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/samples
-[soft_delete]: https://docs.microsoft.com/azure/key-vault/general/soft-delete-overview
+[soft_delete]: /azure/key-vault/general/soft-delete-overview
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-python%2Fsdk%2Fkeyvault%2Fazure-keyvault-secrets%2FREADME.png)
 

--- a/metadata/latest/azure-keyvault-secrets.json
+++ b/metadata/latest/azure-keyvault-secrets.json
@@ -1,6 +1,6 @@
 {
   "Name": "azure-keyvault-secrets",
-  "Version": "4.7.0",
+  "Version": "4.8.0",
   "DevVersion": null,
   "DirectoryPath": "sdk/keyvault/azure-keyvault-secrets",
   "ServiceDirectory": "keyvault",
@@ -10,7 +10,7 @@
   "SdkType": "client",
   "IsNewSdk": true,
   "ArtifactName": "azure-keyvault-secrets",
-  "ReleaseStatus": "2023-03-16",
+  "ReleaseStatus": "2024-02-22",
   "DocsCiConfigProperties": {
     "extension_config": {
       "autodoc_default_options": {


### PR DESCRIPTION
`azure-keyvault-secrets` version 4.8.0 was [successfully released](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3520076&view=results) yesterday, but the ESRP publishing stage erroneously raised an error. This caused other steps, like docs publishing, to get skipped. This PR manually updates docs metadata accordingly.

Based on updates to other KV libraries, e.g. https://github.com/MicrosoftDocs/azure-docs-sdk-python/commit/b98409e3758dafd5bed3ca1095d9aa4494dc3166

The diff displayed here is excessive because of line ending changes; here's a more accurate diff showing that the only updates are to metadata, README content updates (minimum Python version and sample link updates), and links to the Python repo (updating the release tag): https://www.diffchecker.com/ef9mbiIK/