### PR TITLE
Add redirections for simplifying TOC has removed distribution level pages

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -134,5 +134,8 @@
   "need_generate_pdf_url_template": false,
   "docs_build_engine": {
     "name": "docfx_v3"
-  }
+  },
+  "redirection_files": [
+    "redirections/.openpublishing.redirection.simplify-package-structure.json"
+  ]
 }

--- a/redirections/.openpublishing.redirection.simplify-package-structure.json
+++ b/redirections/.openpublishing.redirection.simplify-package-structure.json
@@ -1,0 +1,2324 @@
+{
+    "redirections": [
+        {
+            "source_path_from_root": "/docs-ref-autogen/adal/index.yml",
+            "redirect_url": "/python/api/adal/adal",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-ai-contentsafety/index.yml",
+            "redirect_url": "/python/api/azure-ai-contentsafety/azure.ai.contentsafety",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-ai-formrecognizer/index.yml",
+            "redirect_url": "/python/api/azure-ai-formrecognizer/azure.ai.formrecognizer",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-ai-language-conversations/index.yml",
+            "redirect_url": "/python/api/azure-ai-language-conversations/azure.ai.language.conversations",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-ai-language-questionanswering/index.yml",
+            "redirect_url": "/python/api/azure-ai-language-questionanswering/azure.ai.language.questionanswering",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-ai-metricsadvisor/index.yml",
+            "redirect_url": "/python/api/azure-ai-metricsadvisor/azure.ai.metricsadvisor",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-ai-ml/index.yml",
+            "redirect_url": "/python/api/azure-ai-ml/azure.ai.ml",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-ai-textanalytics/index.yml",
+            "redirect_url": "/python/api/azure-ai-textanalytics/azure.ai.textanalytics",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-ai-translation-document/index.yml",
+            "redirect_url": "/python/api/azure-ai-translation-document/azure.ai.translation.document",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-appconfiguration/index.yml",
+            "redirect_url": "/python/api/azure-appconfiguration/azure.appconfiguration",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-appconfiguration-provider/index.yml",
+            "redirect_url": "/python/api/azure-appconfiguration-provider/azure.appconfiguration.provider",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-batch/index.yml",
+            "redirect_url": "/python/api/azure-batch/azure.batch",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-language-spellcheck/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-language-spellcheck/azure.cognitiveservices.language.spellcheck",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-search-entitysearch/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-entitysearch/azure.cognitiveservices.search.entitysearch",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-search-imagesearch/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-imagesearch/azure.cognitiveservices.search.imagesearch",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-search-newssearch/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-newssearch/azure.cognitiveservices.search.newssearch",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-search-videosearch/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-videosearch/azure.cognitiveservices.search.videosearch",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-search-websearch/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-websearch/azure.cognitiveservices.search.websearch",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-speech/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-speech/azure.cognitiveservices.speech",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-vision-contentmoderator/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-vision-contentmoderator/azure.cognitiveservices.vision.contentmoderator",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cognitiveservices-vision-customvision/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-vision-customvision/azure.cognitiveservices.vision.customvision",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-callautomation/index.yml",
+            "redirect_url": "/python/api/azure-communication-callautomation/azure.communication.callautomation",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-chat/index.yml",
+            "redirect_url": "/python/api/azure-communication-chat/azure.communication.chat",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-email/index.yml",
+            "redirect_url": "/python/api/azure-communication-email/azure.communication.email",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-identity/index.yml",
+            "redirect_url": "/python/api/azure-communication-identity/azure.communication.identity",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-jobrouter/index.yml",
+            "redirect_url": "/python/api/azure-communication-jobrouter/azure.communication.jobrouter",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-messages/index.yml",
+            "redirect_url": "/python/api/azure-communication-messages/azure.communication.messages",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-phonenumbers/index.yml",
+            "redirect_url": "/python/api/azure-communication-phonenumbers/azure.communication.phonenumbers",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-rooms/index.yml",
+            "redirect_url": "/python/api/azure-communication-rooms/azure.communication.rooms",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-communication-sms/index.yml",
+            "redirect_url": "/python/api/azure-communication-sms/azure.communication.sms",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-confidentialledger/index.yml",
+            "redirect_url": "/python/api/azure-confidentialledger/azure.confidentialledger",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-containerregistry/index.yml",
+            "redirect_url": "/python/api/azure-containerregistry/azure.containerregistry",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-core/index.yml",
+            "redirect_url": "/python/api/azure-core/azure.core",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cosmos/index.yml",
+            "redirect_url": "/python/api/azure-cosmos/azure.cosmos",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-cosmosdb-table/index.yml",
+            "redirect_url": "/python/api/azure-cosmosdb-table/azure.cosmosdb.table",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-data-tables/index.yml",
+            "redirect_url": "/python/api/azure-data-tables/azure.data.tables",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-datalake-store/index.yml",
+            "redirect_url": "/python/api/azure-datalake-store/azure.datalake.store",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-developer-loadtesting/index.yml",
+            "redirect_url": "/python/api/azure-developer-loadtesting/azure.developer.loadtesting",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-digitaltwins-core/index.yml",
+            "redirect_url": "/python/api/azure-digitaltwins-core/azure.digitaltwins.core",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-eventgrid/index.yml",
+            "redirect_url": "/python/api/azure-eventgrid/azure.eventgrid",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-eventhub/index.yml",
+            "redirect_url": "/python/api/azure-eventhub/azure.eventhub",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-eventhub-checkpointstoreblob/index.yml",
+            "redirect_url": "/python/api/azure-eventhub-checkpointstoreblob/azure.eventhub.extensions.checkpointstoreblob",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-eventhub-checkpointstoreblob-aio/index.yml",
+            "redirect_url": "/python/api/azure-eventhub-checkpointstoreblob-aio/azure.eventhub.extensions.checkpointstoreblobaio",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-functions/index.yml",
+            "redirect_url": "/python/api/azure-functions/azure.functions",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-functions-durable/index.yml",
+            "redirect_url": "/python/api/azure-functions-durable/azure.durable_functions",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-identity/index.yml",
+            "redirect_url": "/python/api/azure-identity/azure.identity",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-identity-broker/index.yml",
+            "redirect_url": "/python/api/azure-identity-broker/azure.identity.broker",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-iot-device/index.yml",
+            "redirect_url": "/python/api/azure-iot-device/azure.iot.device",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-iot-deviceupdate/index.yml",
+            "redirect_url": "/python/api/azure-iot-deviceupdate/azure.iot.deviceupdate",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-iot-hub/index.yml",
+            "redirect_url": "/python/api/azure-iot-hub/azure.iot.hub",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-keyvault-administration/index.yml",
+            "redirect_url": "/python/api/azure-keyvault-administration/azure.keyvault.administration",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-keyvault-certificates/index.yml",
+            "redirect_url": "/python/api/azure-keyvault-certificates/azure.keyvault.certificates",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-keyvault-keys/index.yml",
+            "redirect_url": "/python/api/azure-keyvault-keys/azure.keyvault.keys",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-keyvault-secrets/index.yml",
+            "redirect_url": "/python/api/azure-keyvault-secrets/azure.keyvault.secrets",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-messaging-webpubsubclient/index.yml",
+            "redirect_url": "/python/api/azure-messaging-webpubsubclient/azure.messaging.webpubsubclient",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-messaging-webpubsubservice/index.yml",
+            "redirect_url": "/python/api/azure-messaging-webpubsubservice/azure.messaging.webpubsubservice",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-advisor/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-advisor/azure.mgmt.advisor",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-alertsmanagement/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-alertsmanagement/azure.mgmt.alertsmanagement",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-apicenter/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-apicenter/azure.mgmt.apicenter",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-appconfiguration/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-appconfiguration/azure.mgmt.appconfiguration",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-appcontainers/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-appcontainers/azure.mgmt.appcontainers",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-applicationinsights/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-applicationinsights/azure.mgmt.applicationinsights",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-appplatform/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-appplatform/azure.mgmt.appplatform",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-attestation/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-attestation/azure.mgmt.attestation",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-authorization/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-authorization/azure.mgmt.authorization",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-automanage/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-automanage/azure.mgmt.automanage",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-automation/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-automation/azure.mgmt.automation",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-avs/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-avs/azure.mgmt.avs",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-azurearcdata/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-azurearcdata/azure.mgmt.azurearcdata",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-azurestack/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-azurestack/azure.mgmt.azurestack",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-azurestackhci/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-azurestackhci/azure.mgmt.azurestackhci",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-baremetalinfrastructure/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-baremetalinfrastructure/azure.mgmt.baremetalinfrastructure",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-batch/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-batch/azure.mgmt.batch",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-billing/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-billing/azure.mgmt.billing",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-botservice/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-botservice/azure.mgmt.botservice",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-cdn/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-cdn/azure.mgmt.cdn",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-changeanalysis/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-changeanalysis/azure.mgmt.changeanalysis",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-chaos/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-chaos/azure.mgmt.chaos",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-cognitiveservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-cognitiveservices/azure.mgmt.cognitiveservices",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-commerce/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-commerce/azure.mgmt.commerce",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-communication/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-communication/azure.mgmt.communication",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-compute/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-compute/azure.mgmt.compute",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-confidentialledger/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-confidentialledger/azure.mgmt.confidentialledger",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-confluent/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-confluent/azure.mgmt.confluent",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-connectedvmware/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-connectedvmware/azure.mgmt.connectedvmware",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-consumption/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-consumption/azure.mgmt.consumption",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-containerinstance/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-containerinstance/azure.mgmt.containerinstance",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-containerregistry/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-containerregistry/azure.mgmt.containerregistry",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-containerservice/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-containerservice/azure.mgmt.containerservice",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-containerservicefleet/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-containerservicefleet/azure.mgmt.containerservicefleet",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-core/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-core/azure.mgmt.core",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-cosmosdb/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-cosmosdb/azure.mgmt.cosmosdb",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-cosmosdbforpostgresql/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-cosmosdbforpostgresql/azure.mgmt.cosmosdbforpostgresql",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-costmanagement/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-costmanagement/azure.mgmt.costmanagement",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-customproviders/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-customproviders/azure.mgmt.customproviders",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-dashboard/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-dashboard/azure.mgmt.dashboard",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-databox/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-databox/azure.mgmt.databox",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-databoxedge/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-databoxedge/azure.mgmt.databoxedge",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-databricks/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-databricks/azure.mgmt.databricks",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-datadog/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datadog/azure.mgmt.datadog",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-datafactory/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datafactory/azure.mgmt.datafactory",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-datamigration/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datamigration/azure.mgmt.datamigration",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-dataprotection/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-dataprotection/azure.mgmt.dataprotection",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-datashare/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datashare/azure.mgmt.datashare",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-deploymentmanager/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-deploymentmanager/azure.mgmt.deploymentmanager",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-desktopvirtualization/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-desktopvirtualization/azure.mgmt.desktopvirtualization",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-devcenter/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-devcenter/azure.mgmt.devcenter",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-deviceupdate/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-deviceupdate/azure.mgmt.deviceupdate",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-devtestlabs/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-devtestlabs/azure.mgmt.devtestlabs",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-digitaltwins/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-digitaltwins/azure.mgmt.digitaltwins",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-dns/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-dns/azure.mgmt.dns",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-dnsresolver/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-dnsresolver/azure.mgmt.dnsresolver",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-dynatrace/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-dynatrace/azure.mgmt.dynatrace",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-edgeorder/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-edgeorder/azure.mgmt.edgeorder",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-elastic/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-elastic/azure.mgmt.elastic",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-elasticsan/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-elasticsan/azure.mgmt.elasticsan",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-eventgrid/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-eventgrid/azure.mgmt.eventgrid",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-eventhub/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-eventhub/azure.mgmt.eventhub",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-extendedlocation/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-extendedlocation/azure.mgmt.extendedlocation",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-fluidrelay/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-fluidrelay/azure.mgmt.fluidrelay",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-frontdoor/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-frontdoor/azure.mgmt.frontdoor",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-graphservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-graphservices/azure.mgmt.graphservices",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-hanaonazure/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hanaonazure/azure.mgmt.hanaonazure",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-hdinsight/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hdinsight/azure.mgmt.hdinsight",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-healthcareapis/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-healthcareapis/azure.mgmt.healthcareapis",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-hybridcompute/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridcompute/azure.mgmt.hybridcompute",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-hybridconnectivity/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridconnectivity/azure.mgmt.hybridconnectivity",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-hybridcontainerservice/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridcontainerservice/azure.mgmt.hybridcontainerservice",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-hybridkubernetes/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridkubernetes/azure.mgmt.hybridkubernetes",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-hybridnetwork/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridnetwork/azure.mgmt.hybridnetwork",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-imagebuilder/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-imagebuilder/azure.mgmt.imagebuilder",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-iotcentral/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-iotcentral/azure.mgmt.iotcentral",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-iotfirmwaredefense/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-iotfirmwaredefense/azure.mgmt.iotfirmwaredefense",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-iothub/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-iothub/azure.mgmt.iothub",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-iothubprovisioningservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-iothubprovisioningservices/azure.mgmt.iothubprovisioningservices",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-keyvault/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-keyvault/azure.mgmt.keyvault",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-kubernetesconfiguration/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-kubernetesconfiguration/azure.mgmt.kubernetesconfiguration",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-kusto/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-kusto/azure.mgmt.kusto",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-labservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-labservices/azure.mgmt.labservices",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-loadtesting/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-loadtesting/azure.mgmt.loadtesting",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-loganalytics/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-loganalytics/azure.mgmt.loganalytics",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-logic/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-logic/azure.mgmt.logic",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-logz/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-logz/azure.mgmt.logz",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-machinelearningservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-machinelearningservices/azure.mgmt.machinelearningservices",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-maintenance/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-maintenance/azure.mgmt.maintenance",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-managednetworkfabric/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-managednetworkfabric/azure.mgmt.managednetworkfabric",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-managedservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-managedservices/azure.mgmt.managedservices",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-managementgroups/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-managementgroups/azure.mgmt.managementgroups",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-managementpartner/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-managementpartner/azure.mgmt.managementpartner",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-maps/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-maps/azure.mgmt.maps",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-marketplaceordering/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-marketplaceordering/azure.mgmt.marketplaceordering",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-media/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-media/azure.mgmt.media",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-mixedreality/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-mixedreality/azure.mgmt.mixedreality",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-mobilenetwork/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-mobilenetwork/azure.mgmt.mobilenetwork",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-monitor/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-monitor/azure.mgmt.monitor",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-msi/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-msi/azure.mgmt.msi",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-netapp/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-netapp/azure.mgmt.netapp",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-network/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-network/azure.mgmt.network",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-networkanalytics/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-networkanalytics/azure.mgmt.networkanalytics",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-networkcloud/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-networkcloud/azure.mgmt.networkcloud",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-newrelicobservability/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-newrelicobservability/azure.mgmt.newrelicobservability",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-nginx/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-nginx/azure.mgmt.nginx",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-notificationhubs/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-notificationhubs/azure.mgmt.notificationhubs",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-operationsmanagement/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-operationsmanagement/azure.mgmt.operationsmanagement",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-orbital/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-orbital/azure.mgmt.orbital",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-paloaltonetworksngfw/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-paloaltonetworksngfw/azure.mgmt.paloaltonetworksngfw",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-peering/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-peering/azure.mgmt.peering",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-policyinsights/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-policyinsights/azure.mgmt.policyinsights",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-portal/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-portal/azure.mgmt.portal",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-powerbidedicated/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-powerbidedicated/azure.mgmt.powerbidedicated",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-privatedns/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-privatedns/azure.mgmt.privatedns",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-purview/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-purview/azure.mgmt.purview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-qumulo/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-qumulo/azure.mgmt.qumulo",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-rdbms/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-rdbms/azure.mgmt.rdbms",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-recoveryservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-recoveryservices/azure.mgmt.recoveryservices",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-recoveryservicesbackup/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-recoveryservicesbackup/azure.mgmt.recoveryservicesbackup",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-recoveryservicessiterecovery/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-recoveryservicessiterecovery/azure.mgmt.recoveryservicessiterecovery",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-redhatopenshift/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-redhatopenshift/azure.mgmt.redhatopenshift",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-redis/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-redis/azure.mgmt.redis",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-redisenterprise/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-redisenterprise/azure.mgmt.redisenterprise",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-relay/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-relay/azure.mgmt.relay",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-resource/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-resource/azure.mgmt.resource",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-resourceconnector/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-resourceconnector/azure.mgmt.resourceconnector",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-resourcegraph/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-resourcegraph/azure.mgmt.resourcegraph",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-resourcemover/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-resourcemover/azure.mgmt.resourcemover",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-scheduler/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-scheduler/azure.mgmt.scheduler",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-search/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-search/azure.mgmt.search",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-security/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-security/azure.mgmt.security",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-securityinsight/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-securityinsight/azure.mgmt.securityinsight",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-selfhelp/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-selfhelp/azure.mgmt.selfhelp",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-serialconsole/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-serialconsole/azure.mgmt.serialconsole",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-servicebus/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicebus/azure.mgmt.servicebus",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-servicefabric/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicefabric/azure.mgmt.servicefabric",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-servicefabricmanagedclusters/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicefabricmanagedclusters/azure.mgmt.servicefabricmanagedclusters",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-servicelinker/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicelinker/azure.mgmt.servicelinker",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-servicenetworking/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicenetworking/azure.mgmt.servicenetworking",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-sphere/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-sphere/azure.mgmt.sphere",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-sql/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-sql/azure.mgmt.sql",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-storage/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storage/azure.mgmt.storage",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-storagecache/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storagecache/azure.mgmt.storagecache",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-storagemover/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storagemover/azure.mgmt.storagemover",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-storagepool/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storagepool/azure.mgmt.storagepool",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-storagesync/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storagesync/azure.mgmt.storagesync",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-streamanalytics/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-streamanalytics/azure.mgmt.streamanalytics",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-subscription/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-subscription/azure.mgmt.subscription",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-support/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-support/azure.mgmt.support",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-synapse/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-synapse/azure.mgmt.synapse",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-timeseriesinsights/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-timeseriesinsights/azure.mgmt.timeseriesinsights",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-trafficmanager/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-trafficmanager/azure.mgmt.trafficmanager",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-voiceservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-voiceservices/azure.mgmt.voiceservices",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-web/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-web/azure.mgmt.web",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-webpubsub/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-webpubsub/azure.mgmt.webpubsub",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-mgmt-workloads/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-workloads/azure.mgmt.workloads",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-monitor-ingestion/index.yml",
+            "redirect_url": "/python/api/azure-monitor-ingestion/azure.monitor.ingestion",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-monitor-opentelemetry/index.yml",
+            "redirect_url": "/python/api/azure-monitor-opentelemetry/azure.monitor.opentelemetry",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-monitor-query/index.yml",
+            "redirect_url": "/python/api/azure-monitor-query/azure.monitor.query",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-schemaregistry/index.yml",
+            "redirect_url": "/python/api/azure-schemaregistry/azure.schemaregistry",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-schemaregistry-avroencoder/index.yml",
+            "redirect_url": "/python/api/azure-schemaregistry-avroencoder/azure.schemaregistry.encoder.avroencoder",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-search-documents/index.yml",
+            "redirect_url": "/python/api/azure-search-documents/azure.search.documents",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-security-attestation/index.yml",
+            "redirect_url": "/python/api/azure-security-attestation/azure.security.attestation",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-servicebus/index.yml",
+            "redirect_url": "/python/api/azure-servicebus/azure.servicebus",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-servicefabric/index.yml",
+            "redirect_url": "/python/api/azure-servicefabric/azure.servicefabric",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-storage-blob/index.yml",
+            "redirect_url": "/python/api/azure-storage-blob/azure.storage.blob",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-storage-file/index.yml",
+            "redirect_url": "/python/api/azure-storage-file/azure.storage.file",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-storage-file-datalake/index.yml",
+            "redirect_url": "/python/api/azure-storage-file-datalake/azure.storage.filedatalake",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-storage-file-share/index.yml",
+            "redirect_url": "/python/api/azure-storage-file-share/azure.storage.fileshare",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azure-storage-queue/index.yml",
+            "redirect_url": "/python/api/azure-storage-queue/azure.storage.queue",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/azureml-featurestore/index.yml",
+            "redirect_url": "/python/api/azureml-featurestore/azureml.featurestore",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/docs-ref-autogen/uamqp/index.yml",
+            "redirect_url": "/python/api/uamqp/uamqp",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-agrifood-farming/index.yml",
+            "redirect_url": "/python/api/azure-agrifood-farming/azure.agrifood.farming?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-ai-anomalydetector/index.yml",
+            "redirect_url": "/python/api/azure-ai-anomalydetector/azure.ai.anomalydetector?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-ai-contentsafety/index.yml",
+            "redirect_url": "/python/api/azure-ai-contentsafety/azure.ai.contentsafety?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-ai-documentintelligence/index.yml",
+            "redirect_url": "/python/api/azure-ai-documentintelligence/azure.ai.documentintelligence?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-ai-generative/index.yml",
+            "redirect_url": "/python/api/azure-ai-generative/azure.ai.generative?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-ai-personalizer/index.yml",
+            "redirect_url": "/python/api/azure-ai-personalizer/azure.ai.personalizer?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-ai-resources/index.yml",
+            "redirect_url": "/python/api/azure-ai-resources/azure.ai.resources?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-ai-translation-text/index.yml",
+            "redirect_url": "/python/api/azure-ai-translation-text/azure.ai.translation.text?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-ai-vision-imageanalysis/index.yml",
+            "redirect_url": "/python/api/azure-ai-vision-imageanalysis/azure.ai.vision.imageanalysis?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-appconfiguration/index.yml",
+            "redirect_url": "/python/api/azure-appconfiguration/azure.appconfiguration?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-appconfiguration-provider/index.yml",
+            "redirect_url": "/python/api/azure-appconfiguration-provider/azure.appconfiguration.provider?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-knowledge-qnamaker/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-knowledge-qnamaker/azure.cognitiveservices.knowledge.qnamaker?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-language-luis/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-language-luis/azure.cognitiveservices.language.luis?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-personalizer/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-personalizer/azure.cognitiveservices.personalizer?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-search-autosuggest/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-autosuggest/azure.cognitiveservices.search.autosuggest?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-search-customimagesearch/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-customimagesearch/azure.cognitiveservices.search.customimagesearch?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-search-customsearch/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-customsearch/azure.cognitiveservices.search.customsearch?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-search-visualsearch/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-search-visualsearch/azure.cognitiveservices.search.visualsearch?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-vision-computervision/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-vision-computervision/azure.cognitiveservices.vision.computervision?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cognitiveservices-vision-face/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-vision-face/azure.cognitiveservices.vision.face?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-communication-administration/index.yml",
+            "redirect_url": "/python/api/azure-communication-administration/azure.communication.administration?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-communication-callautomation/index.yml",
+            "redirect_url": "/python/api/azure-communication-callautomation/azure.communication.callautomation?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-communication-identity/index.yml",
+            "redirect_url": "/python/api/azure-communication-identity/azure.communication.identity?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-communication-jobrouter/index.yml",
+            "redirect_url": "/python/api/azure-communication-jobrouter/azure.communication.jobrouter?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-communication-phonenumbers/index.yml",
+            "redirect_url": "/python/api/azure-communication-phonenumbers/azure.communication.phonenumbers?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-communication-rooms/index.yml",
+            "redirect_url": "/python/api/azure-communication-rooms/azure.communication.rooms?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-core-experimental/index.yml",
+            "redirect_url": "/python/api/azure-core-experimental/azure.core.experimental?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-core-tracing-opencensus/index.yml",
+            "redirect_url": "/python/api/azure-core-tracing-opencensus/azure.core.tracing.ext.opencensus_span?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-core-tracing-opentelemetry/index.yml",
+            "redirect_url": "/python/api/azure-core-tracing-opentelemetry/azure.core.tracing.ext.opentelemetry_span?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-cosmos/index.yml",
+            "redirect_url": "/python/api/azure-cosmos/azure.cosmos?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-defender-easm/index.yml",
+            "redirect_url": "/python/api/azure-defender-easm/azure.defender.easm?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-developer-devcenter/index.yml",
+            "redirect_url": "/python/api/azure-developer-devcenter/azure.developer.devcenter?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-eventgrid/index.yml",
+            "redirect_url": "/python/api/azure-eventgrid/azure.eventgrid?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-healthinsights-cancerprofiling/index.yml",
+            "redirect_url": "/python/api/azure-healthinsights-cancerprofiling/azure.healthinsights.cancerprofiling?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-healthinsights-clinicalmatching/index.yml",
+            "redirect_url": "/python/api/azure-healthinsights-clinicalmatching/azure.healthinsights.clinicalmatching?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-healthinsights-radiologyinsights/index.yml",
+            "redirect_url": "/python/api/azure-healthinsights-radiologyinsights/azure.healthinsights.radiologyinsights?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-identity/index.yml",
+            "redirect_url": "/python/api/azure-identity/azure.identity?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-identity-broker/index.yml",
+            "redirect_url": "/python/api/azure-identity-broker/azure.identity.broker?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-iot-device/index.yml",
+            "redirect_url": "/python/api/azure-iot-device/azure.iot.device?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-iot-deviceprovisioning/index.yml",
+            "redirect_url": "/python/api/azure-iot-deviceprovisioning/azure.iot.deviceprovisioning?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-iot-modelsrepository/index.yml",
+            "redirect_url": "/python/api/azure-iot-modelsrepository/azure.iot.modelsrepository?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-keyvault-administration/index.yml",
+            "redirect_url": "/python/api/azure-keyvault-administration/azure.keyvault.administration?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-keyvault-certificates/index.yml",
+            "redirect_url": "/python/api/azure-keyvault-certificates/azure.keyvault.certificates?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-keyvault-keys/index.yml",
+            "redirect_url": "/python/api/azure-keyvault-keys/azure.keyvault.keys?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-keyvault-secrets/index.yml",
+            "redirect_url": "/python/api/azure-keyvault-secrets/azure.keyvault.secrets?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-maps-geolocation/index.yml",
+            "redirect_url": "/python/api/azure-maps-geolocation/azure.maps.geolocation?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-maps-render/index.yml",
+            "redirect_url": "/python/api/azure-maps-render/azure.maps.render?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-maps-route/index.yml",
+            "redirect_url": "/python/api/azure-maps-route/azure.maps.route?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-maps-search/index.yml",
+            "redirect_url": "/python/api/azure-maps-search/azure.maps.search?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-media-analytics-edge/index.yml",
+            "redirect_url": "/python/api/azure-media-analytics-edge/azure.media.analyticsedge?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-media-videoanalyzer-edge/index.yml",
+            "redirect_url": "/python/api/azure-media-videoanalyzer-edge/azure.media.videoanalyzeredge?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-messaging-webpubsubclient/index.yml",
+            "redirect_url": "/python/api/azure-messaging-webpubsubclient/azure.messaging.webpubsubclient?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-messaging-webpubsubservice/index.yml",
+            "redirect_url": "/python/api/azure-messaging-webpubsubservice/azure.messaging.webpubsubservice?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-advisor/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-advisor/azure.mgmt.advisor?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-agrifood/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-agrifood/azure.mgmt.agrifood?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-alertsmanagement/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-alertsmanagement/azure.mgmt.alertsmanagement?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-apicenter/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-apicenter/azure.mgmt.apicenter?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-appcomplianceautomation/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-appcomplianceautomation/azure.mgmt.appcomplianceautomation?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-appcontainers/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-appcontainers/azure.mgmt.appcontainers?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-astro/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-astro/azure.mgmt.astro?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-attestation/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-attestation/azure.mgmt.attestation?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-automanage/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-automanage/azure.mgmt.automanage?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-automation/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-automation/azure.mgmt.automation?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-azurearcdata/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-azurearcdata/azure.mgmt.azurearcdata?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-azurelargeinstance/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-azurelargeinstance/azure.mgmt.azurelargeinstance?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-azurestack/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-azurestack/azure.mgmt.azurestack?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-azurestackhci/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-azurestackhci/azure.mgmt.azurestackhci?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-baremetalinfrastructure/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-baremetalinfrastructure/azure.mgmt.baremetalinfrastructure?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-billing/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-billing/azure.mgmt.billing?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-billingbenefits/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-billingbenefits/azure.mgmt.billingbenefits?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-cdn/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-cdn/azure.mgmt.cdn?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-chaos/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-chaos/azure.mgmt.chaos?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-commerce/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-commerce/azure.mgmt.commerce?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-communication/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-communication/azure.mgmt.communication?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-confidentialledger/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-confidentialledger/azure.mgmt.confidentialledger?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-confluent/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-confluent/azure.mgmt.confluent?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-connectedvmware/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-connectedvmware/azure.mgmt.connectedvmware?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-consumption/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-consumption/azure.mgmt.consumption?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-containerservicefleet/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-containerservicefleet/azure.mgmt.containerservicefleet?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-cosmosdb/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-cosmosdb/azure.mgmt.cosmosdb?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-cosmosdbforpostgresql/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-cosmosdbforpostgresql/azure.mgmt.cosmosdbforpostgresql?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-customproviders/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-customproviders/azure.mgmt.customproviders?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-dashboard/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-dashboard/azure.mgmt.dashboard?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-databoxedge/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-databoxedge/azure.mgmt.databoxedge?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-datadog/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datadog/azure.mgmt.datadog?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-datalake-analytics/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datalake-analytics/azure.mgmt.datalake.analytics?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-datalake-store/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datalake-store/azure.mgmt.datalake.store?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-datamigration/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datamigration/azure.mgmt.datamigration?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-datashare/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-datashare/azure.mgmt.datashare?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-defendereasm/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-defendereasm/azure.mgmt.defendereasm?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-deploymentmanager/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-deploymentmanager/azure.mgmt.deploymentmanager?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-devcenter/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-devcenter/azure.mgmt.devcenter?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-devhub/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-devhub/azure.mgmt.devhub?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-deviceupdate/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-deviceupdate/azure.mgmt.deviceupdate?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-devspaces/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-devspaces/azure.mgmt.devspaces?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-devtestlabs/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-devtestlabs/azure.mgmt.devtestlabs?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-dnsresolver/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-dnsresolver/azure.mgmt.dnsresolver?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-edgeorder/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-edgeorder/azure.mgmt.edgeorder?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-education/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-education/azure.mgmt.education?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-elastic/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-elastic/azure.mgmt.elastic?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-elasticsan/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-elasticsan/azure.mgmt.elasticsan?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-eventgrid/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-eventgrid/azure.mgmt.eventgrid?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-extendedlocation/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-extendedlocation/azure.mgmt.extendedlocation?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-fluidrelay/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-fluidrelay/azure.mgmt.fluidrelay?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-guestconfig/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-guestconfig/azure.mgmt.guestconfig?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-hanaonazure/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hanaonazure/azure.mgmt.hanaonazure?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-hardwaresecuritymodules/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hardwaresecuritymodules/azure.mgmt.hardwaresecuritymodules?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-hdinsightcontainers/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hdinsightcontainers/azure.mgmt.hdinsightcontainers?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-healthbot/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-healthbot/azure.mgmt.healthbot?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-healthcareapis/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-healthcareapis/azure.mgmt.healthcareapis?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-hybridcompute/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridcompute/azure.mgmt.hybridcompute?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-hybridcontainerservice/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridcontainerservice/azure.mgmt.hybridcontainerservice?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-hybridkubernetes/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridkubernetes/azure.mgmt.hybridkubernetes?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-hybridnetwork/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-hybridnetwork/azure.mgmt.hybridnetwork?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-iotcentral/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-iotcentral/azure.mgmt.iotcentral?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-iotfirmwaredefense/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-iotfirmwaredefense/azure.mgmt.iotfirmwaredefense?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-iothubprovisioningservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-iothubprovisioningservices/azure.mgmt.iothubprovisioningservices?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-labservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-labservices/azure.mgmt.labservices?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-loganalytics/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-loganalytics/azure.mgmt.loganalytics?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-logic/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-logic/azure.mgmt.logic?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-logz/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-logz/azure.mgmt.logz?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-machinelearningcompute/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-machinelearningcompute/azure.mgmt.machinelearningcompute?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-machinelearningservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-machinelearningservices/azure.mgmt.machinelearningservices?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-maintenance/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-maintenance/azure.mgmt.maintenance?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-managedapplications/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-managedapplications/azure.mgmt.managedapplications?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-managedservices/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-managedservices/azure.mgmt.managedservices?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-managementgroups/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-managementgroups/azure.mgmt.managementgroups?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-managementpartner/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-managementpartner/azure.mgmt.managementpartner?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-marketplaceordering/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-marketplaceordering/azure.mgmt.marketplaceordering?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-mixedreality/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-mixedreality/azure.mgmt.mixedreality?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-msi/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-msi/azure.mgmt.msi?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-netapp/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-netapp/azure.mgmt.netapp?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-networkanalytics/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-networkanalytics/azure.mgmt.networkanalytics?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-networkfunction/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-networkfunction/azure.mgmt.networkfunction?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-nginx/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-nginx/azure.mgmt.nginx?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-notificationhubs/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-notificationhubs/azure.mgmt.notificationhubs?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-oep/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-oep/azure.mgmt.oep?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-operationsmanagement/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-operationsmanagement/azure.mgmt.operationsmanagement?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-paloaltonetworksngfw/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-paloaltonetworksngfw/azure.mgmt.paloaltonetworksngfw?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-peering/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-peering/azure.mgmt.peering?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-playwrighttesting/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-playwrighttesting/azure.mgmt.playwrighttesting?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-policyinsights/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-policyinsights/azure.mgmt.policyinsights?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-portal/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-portal/azure.mgmt.portal?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-powerbidedicated/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-powerbidedicated/azure.mgmt.powerbidedicated?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-purview/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-purview/azure.mgmt.purview?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-quantum/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-quantum/azure.mgmt.quantum?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-rdbms/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-rdbms/azure.mgmt.rdbms?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-recoveryservicesdatareplication/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-recoveryservicesdatareplication/azure.mgmt.recoveryservicesdatareplication?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-redisenterprise/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-redisenterprise/azure.mgmt.redisenterprise?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-relay/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-relay/azure.mgmt.relay?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-resource/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-resource/azure.mgmt.resource?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-resourcegraph/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-resourcegraph/azure.mgmt.resourcegraph?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-resourcehealth/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-resourcehealth/azure.mgmt.resourcehealth?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-resourcemover/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-resourcemover/azure.mgmt.resourcemover?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-scheduler/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-scheduler/azure.mgmt.scheduler?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-scvmm/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-scvmm/azure.mgmt.scvmm?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-search/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-search/azure.mgmt.search?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-securitydevops/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-securitydevops/azure.mgmt.securitydevops?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-securityinsight/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-securityinsight/azure.mgmt.securityinsight?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-selfhelp/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-selfhelp/azure.mgmt.selfhelp?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-serialconsole/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-serialconsole/azure.mgmt.serialconsole?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-servicefabric/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicefabric/azure.mgmt.servicefabric?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-servicefabricmanagedclusters/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicefabricmanagedclusters/azure.mgmt.servicefabricmanagedclusters?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-servicelinker/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicelinker/azure.mgmt.servicelinker?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-servicenetworking/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-servicenetworking/azure.mgmt.servicenetworking?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-signalr/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-signalr/azure.mgmt.signalr?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-sphere/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-sphere/azure.mgmt.sphere?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-springappdiscovery/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-springappdiscovery/azure.mgmt.springappdiscovery?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-sql/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-sql/azure.mgmt.sql?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-sqlvirtualmachine/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-sqlvirtualmachine/azure.mgmt.sqlvirtualmachine?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-storageactions/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storageactions/azure.mgmt.storageactions?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-storagecache/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storagecache/azure.mgmt.storagecache?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-storagemover/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storagemover/azure.mgmt.storagemover?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-storagepool/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storagepool/azure.mgmt.storagepool?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-storagesync/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storagesync/azure.mgmt.storagesync?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-streamanalytics/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-streamanalytics/azure.mgmt.streamanalytics?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-subscription/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-subscription/azure.mgmt.subscription?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-support/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-support/azure.mgmt.support?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-synapse/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-synapse/azure.mgmt.synapse?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-testbase/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-testbase/azure.mgmt.testbase?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-timeseriesinsights/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-timeseriesinsights/azure.mgmt.timeseriesinsights?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-vmwarecloudsimple/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-vmwarecloudsimple/azure.mgmt.vmwarecloudsimple?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-webpubsub/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-webpubsub/azure.mgmt.webpubsub?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mgmt-workloadssapvirtualinstance/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-workloadssapvirtualinstance/azure.mgmt.workloadssapvirtualinstance?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mixedreality-authentication/index.yml",
+            "redirect_url": "/python/api/azure-mixedreality-authentication/azure.mixedreality.authentication?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-mixedreality-remoterendering/index.yml",
+            "redirect_url": "/python/api/azure-mixedreality-remoterendering/azure.mixedreality.remoterendering?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-monitor-opentelemetry-exporter/index.yml",
+            "redirect_url": "/python/api/azure-monitor-opentelemetry-exporter/azure.monitor.opentelemetry.exporter?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-monitor-query/index.yml",
+            "redirect_url": "/python/api/azure-monitor-query/azure.monitor.query?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-purview-account/index.yml",
+            "redirect_url": "/python/api/azure-purview-account/azure.purview.account?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-purview-administration/index.yml",
+            "redirect_url": "/python/api/azure-purview-administration/azure.purview.administration?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-purview-catalog/index.yml",
+            "redirect_url": "/python/api/azure-purview-catalog/azure.purview.catalog?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-purview-datamap/index.yml",
+            "redirect_url": "/python/api/azure-purview-datamap/azure.purview.datamap?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-purview-scanning/index.yml",
+            "redirect_url": "/python/api/azure-purview-scanning/azure.purview.scanning?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-purview-sharing/index.yml",
+            "redirect_url": "/python/api/azure-purview-sharing/azure.purview.sharing?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-purview-workflow/index.yml",
+            "redirect_url": "/python/api/azure-purview-workflow/azure.purview.workflow?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-schemaregistry/index.yml",
+            "redirect_url": "/python/api/azure-schemaregistry/azure.schemaregistry?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-schemaregistry-avroserializer/index.yml",
+            "redirect_url": "/python/api/azure-schemaregistry-avroserializer/azure.schemaregistry.serializer?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-search-documents/index.yml",
+            "redirect_url": "/python/api/azure-search-documents/azure.search.documents?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-servicemanagement-legacy/index.yml",
+            "redirect_url": "/python/api/azure-servicemanagement-legacy/azure.servicemanagement.constants?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-storage-blob/index.yml",
+            "redirect_url": "/python/api/azure-storage-blob/azure.storage.blob?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-storage-blob-changefeed/index.yml",
+            "redirect_url": "/python/api/azure-storage-blob-changefeed/azure.storage.blob.changefeed?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-storage-file-datalake/index.yml",
+            "redirect_url": "/python/api/azure-storage-file-datalake/azure.storage.filedatalake?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-storage-file-share/index.yml",
+            "redirect_url": "/python/api/azure-storage-file-share/azure.storage.fileshare?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-storage-queue/index.yml",
+            "redirect_url": "/python/api/azure-storage-queue/azure.storage.queue?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-synapse/index.yml",
+            "redirect_url": "/python/api/azure-synapse/azure.synapse?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-synapse-accesscontrol/index.yml",
+            "redirect_url": "/python/api/azure-synapse-accesscontrol/azure.synapse.accesscontrol?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-synapse-artifacts/index.yml",
+            "redirect_url": "/python/api/azure-synapse-artifacts/azure.synapse.artifacts?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-synapse-managedprivateendpoints/index.yml",
+            "redirect_url": "/python/api/azure-synapse-managedprivateendpoints/azure.synapse.managedprivateendpoints?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-synapse-monitoring/index.yml",
+            "redirect_url": "/python/api/azure-synapse-monitoring/azure.synapse.monitoring?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-synapse-spark/index.yml",
+            "redirect_url": "/python/api/azure-synapse-spark/azure.synapse.spark?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/azure-template/index.yml",
+            "redirect_url": "/python/api/azure-template/azure.template?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/preview/docs-ref-autogen/corehttp/index.yml",
+            "redirect_url": "/python/api/corehttp/corehttp?view=azure-python-preview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-ai-vision/index.yml",
+            "redirect_url": "/python/api/azure-ai-vision/azure.ai.vision?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-applicationinsights/index.yml",
+            "redirect_url": "/python/api/azure-applicationinsights/azure.applicationinsights?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-cognitiveservices-anomalydetector/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-anomalydetector/azure.cognitiveservices.anomalydetector?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-cognitiveservices-language-textanalytics/index.yml",
+            "redirect_url": "/python/api/azure-cognitiveservices-language-textanalytics/azure.cognitiveservices.language.textanalytics?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-common/index.yml",
+            "redirect_url": "/python/api/azure-common/azure.common?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-communication-networktraversal/index.yml",
+            "redirect_url": "/python/api/azure-communication-networktraversal/azure.communication.networktraversal?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-cosmos/index.yml",
+            "redirect_url": "/python/api/azure-cosmos/azure.cosmos?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-graphrbac/index.yml",
+            "redirect_url": "/python/api/azure-graphrbac/azure.graphrbac?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-keyvault/index.yml",
+            "redirect_url": "/python/api/azure-keyvault/azure.keyvault?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-loganalytics/index.yml",
+            "redirect_url": "/python/api/azure-loganalytics/azure.loganalytics?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-agfood/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-agfood/azure.mgmt.agfood?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-app/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-app/azure.mgmt.app?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-azureadb2c/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-azureadb2c/azure.mgmt.azureadb2c?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-batchai/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-batchai/azure.mgmt.batchai?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-edgegateway/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-edgegateway/azure.mgmt.edgegateway?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-powerbiembedded/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-powerbiembedded/azure.mgmt.powerbiembedded?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-storageimportexport/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-storageimportexport/azure.mgmt.storageimportexport?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-videoanalyzer/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-videoanalyzer/azure.mgmt.videoanalyzer?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-mgmt-workloadmonitor/index.yml",
+            "redirect_url": "/python/api/azure-mgmt-workloadmonitor/azure.mgmt.workloadmonitor?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-storage-blob/index.yml",
+            "redirect_url": "/python/api/azure-storage-blob/azure.storage.blob?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-storage-common/index.yml",
+            "redirect_url": "/python/api/azure-storage-common/azure.storage.common?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-storage-file/index.yml",
+            "redirect_url": "/python/api/azure-storage-file/azure.storage.file?view=azure-python-previous",
+            "redirect_document_id": false
+        },
+        {
+            "source_path_from_root": "/previous/docs-ref-autogen/azure-storage-queue/index.yml",
+            "redirect_url": "/python/api/azure-storage-queue/azure.storage.queue?view=azure-python-previous",
+            "redirect_document_id": false
+        }
+    ]
+}


### PR DESCRIPTION
Add `.openpublishing.redirection.simplify-package-structure.json` containing redirections from previously distribution level pages (now removed from main branch) to top level namespaces.