### PR TITLE
Add docsms-allowlist directory to allow list for the repository

### DIFF
--- a/docsms-allowlist/python-allowlist.txt
+++ b/docsms-allowlist/python-allowlist.txt
@@ -6,4 +6,5 @@
 ^previous/docs-ref-autogen/
 ^preview/docs-ref-autogen/
 ^xrefmap\.yml
+^docsms-allowlist/
 docfx.json


### PR DESCRIPTION
My preview PR updated the allow list and that change failed the auto-merge. The allow list isn't a file that's often updated and, even then, is only updated by hand, not automation. Don't prevent the auto-merge from main->live for allow list changes.