### PR TITLE
Exclude publishing of -index.md files in docfx.json

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -6,6 +6,9 @@
           "**/*.md",
           "**/*.yml"
         ],
+        "exclude": [
+          "**/*-index.md"
+        ],
         "src": "docs-ref-services/latest",
         "group": "latest",
         "dest": "api/overview/azure"
@@ -15,6 +18,9 @@
           "**/*.md",
           "**/*.yml"
         ],
+        "exclude": [
+          "**/*-index.md"
+        ],
         "src": "docs-ref-services/preview",
         "group": "preview",
         "dest": "api/overview/azure"
@@ -23,6 +29,9 @@
         "files": [
           "**/*.md",
           "**/*.yml"
+        ],
+        "exclude": [
+          "**/*-index.md"
         ],
         "src": "docs-ref-services/legacy",
         "group": "previous",
@@ -51,7 +60,7 @@
       },
       {
         "files": [
-          "**/*.yml"          
+          "**/*.yml"
         ],
         "src": "docs-ref-autogen",
         "group": "latest",
@@ -63,7 +72,7 @@
       },
       {
         "files": [
-          "**/*.yml"          
+          "**/*.yml"
         ],
         "src": "eph/docs-ref-autogen",
         "group": "latest",
@@ -554,7 +563,7 @@
       "feedback_product_url": {
         "docs-ref-autogen/azure-functions/**/*.yml": "https://github.com/Azure/azure-functions-python-worker/issues",
         "docs-ref-autogen/azure-functions-durable/**/*.yml": "https://github.com/Azure/azure-functions-python-worker/issues",
-        "docs-ref-services/latest/functions.md": "https://github.com/Azure/azure-functions-python-worker/issues"        
+        "docs-ref-services/latest/functions.md": "https://github.com/Azure/azure-functions-python-worker/issues"
       }
     },
     "template": [],


### PR DESCRIPTION
The -index.md files are consumed by service-level overview pages and as such should not be published.

#Fixes https://github.com/Azure/azure-sdk-for-python/issues/31148