### PR TITLE
Update openai dependency

### DIFF
--- a/ci-configs/packages-latest.json
+++ b/ci-configs/packages-latest.json
@@ -3738,9 +3738,9 @@
       "install_type": "pypi"
     },
     {
-      "version": "0.28.1",
+      "version": "1.47.1",
       "name": "openai",
-      "comment": "Needed for azure-ai-generative which has extras in it setup.py",
+      "comment": "Needed for azure-ai-generative and azure-ai-evalation which has extras in it setup.py",
       "install_type": "pypi"
     },
     {

--- a/ci-configs/packages-preview.json
+++ b/ci-configs/packages-preview.json
@@ -3733,9 +3733,9 @@
       "install_type": "pypi"
     },
     {
-      "version": "0.28.1",
+      "version": "1.47.1",
       "name": "openai",
-      "comment": "Needed for azure-ai-generative which has extras in it setup.py",
+      "comment": "Needed for azure-ai-generative and azure-ai-evalation which has extras in it setup.py",
       "install_type": "pypi"
     },
     {


### PR DESCRIPTION
This PR is due to https://dev.azure.com/ceapex/Engineering/_workitems/edit/1000880. This was tested in the pipeline with 1.47.0 (it's in that linked issue) however 1.47.1 was released this morning. I also checked with the owner of python owner azure-ai-* and anything openai > 1.0.0 should work jsut fine.