### PR TITLE
Set openai to 1.47.0

### DIFF
--- a/ci-configs/packages-latest.json
+++ b/ci-configs/packages-latest.json
@@ -3738,7 +3738,7 @@
       "install_type": "pypi"
     },
     {
-      "version": "1.47.1",
+      "version": "1.47.0",
       "name": "openai",
       "comment": "Needed for azure-ai-generative and azure-ai-evalation which has extras in it setup.py",
       "install_type": "pypi"

--- a/ci-configs/packages-preview.json
+++ b/ci-configs/packages-preview.json
@@ -3733,7 +3733,7 @@
       "install_type": "pypi"
     },
     {
-      "version": "1.47.1",
+      "version": "1.47.0",
       "name": "openai",
       "comment": "Needed for azure-ai-generative and azure-ai-evalation which has extras in it setup.py",
       "install_type": "pypi"


### PR DESCRIPTION
Apparently, the [content feeds](https://apidrop.visualstudio.com/Content%20CI/_artifacts/feed/Content_CI_PublicPackages/PyPI/openai/versions/1.47.0) take a while to get newer versions and 1.47.1 was released this morning and hasn't updated. Setting this to the latest released version since 1.47.0 doesn't matter.