### PR TITLE
Remove deprecated ms.prod and ms.technology metadata

### DIFF
--- a/docs-ref-services/communication-administration-readme-pre.md
+++ b/docs-ref-services/communication-administration-readme-pre.md
@@ -5,8 +5,6 @@ ms.date: 04/16/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 [![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/azure-sdk-for-python.client?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=46?branchName=master)
 

--- a/docs-ref-services/latest/adls-gen1-client.md
+++ b/docs-ref-services/latest/adls-gen1-client.md
@@ -6,7 +6,6 @@ ms.date: 08/26/2019
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-data-lake-storage
-ms.technology: azure
 manager: pkasturi
 ---
 # azure-datalake-store

--- a/docs-ref-services/latest/agrifood-nspkg-readme.md
+++ b/docs-ref-services/latest/agrifood-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/10/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure AgriFood SDK for Python
 

--- a/docs-ref-services/latest/ai-language-nspkg-readme.md
+++ b/docs-ref-services/latest/ai-language-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/28/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/azure-mgmt-core-readme.md
+++ b/docs-ref-services/latest/azure-mgmt-core-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/30/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Azure Management Core Library
 

--- a/docs-ref-services/latest/azure.mgmt.resource.md
+++ b/docs-ref-services/latest/azure.mgmt.resource.md
@@ -6,7 +6,6 @@ ms.date: 06/19/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Resources libraries for Python 

--- a/docs-ref-services/latest/cognitiveservices/bing-custom-image-search-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/bing-custom-image-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Image Search
 

--- a/docs-ref-services/latest/cognitiveservices/bing-custom-search-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/bing-custom-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Search
 

--- a/docs-ref-services/latest/cognitiveservices/bing-entity-search-api-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/bing-entity-search-api-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Entity Search
 

--- a/docs-ref-services/latest/cognitiveservices/bing-image-search-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/bing-image-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Image Search
 

--- a/docs-ref-services/latest/cognitiveservices/bing-news-search-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/bing-news-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing News Search
 

--- a/docs-ref-services/latest/cognitiveservices/bing-video-search-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/bing-video-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Video Search
 

--- a/docs-ref-services/latest/cognitiveservices/bing-visual-search-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/bing-visual-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Visual Search
 

--- a/docs-ref-services/latest/cognitiveservices/bing-web-search-api-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/bing-web-search-api-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Web Search API
 

--- a/docs-ref-services/latest/cognitiveservices/face-readme.md
+++ b/docs-ref-services/latest/cognitiveservices/face-readme.md
@@ -5,7 +5,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: face-api
-ms.technology: azure
 ---
 # Azure Face API
 

--- a/docs-ref-services/latest/common-readme.md
+++ b/docs-ref-services/latest/common-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/03/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/communication-networktraversal-readme.md
+++ b/docs-ref-services/latest/communication-networktraversal-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/04/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Azure Communication Network Traversal Package client library for Python - version 1.0.0 
 

--- a/docs-ref-services/latest/communication-phonenumbers-readme.md
+++ b/docs-ref-services/latest/communication-phonenumbers-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/29/2023
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Azure Communication Phone Numbers Package client library for Python - version 1.1.0 
 

--- a/docs-ref-services/latest/communication-sms-readme.md
+++ b/docs-ref-services/latest/communication-sms-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/08/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Azure Communication SMS Package client library for Python - version 1.0.1 
 

--- a/docs-ref-services/latest/data-nspkg-readme.md
+++ b/docs-ref-services/latest/data-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure Data SDK for Python
 

--- a/docs-ref-services/latest/database-for-mysql-postgres.md
+++ b/docs-ref-services/latest/database-for-mysql-postgres.md
@@ -6,7 +6,6 @@ ms.date: 10/02/2019
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Database for MySQL/PostgreSQL libraries for Python

--- a/docs-ref-services/latest/eventhub-checkpointstoreblob-aio-readme.md
+++ b/docs-ref-services/latest/eventhub-checkpointstoreblob-aio-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/07/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure EventHubs Checkpoint Store client library for Python - version 1.1.4 
  using Storage Blobs

--- a/docs-ref-services/latest/eventhub-checkpointstoreblob-readme.md
+++ b/docs-ref-services/latest/eventhub-checkpointstoreblob-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/07/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure EventHubs Checkpoint Store client library for Python - version 1.1.4 
  using Storage Blobs

--- a/docs-ref-services/latest/keyvault-readme.md
+++ b/docs-ref-services/latest/keyvault-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/29/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault client libraries for Python
 

--- a/docs-ref-services/latest/messaging-nspkg-readme.md
+++ b/docs-ref-services/latest/messaging-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/24/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-advisor-readme.md
+++ b/docs-ref-services/latest/mgmt-advisor-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: applied-ai-services
 ms.subservice: metrics-advisor
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-alertsmanagement-readme.md
+++ b/docs-ref-services/latest/mgmt-alertsmanagement-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: azure-monitor
 ms.subservice: alerts
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-attestation-readme.md
+++ b/docs-ref-services/latest/mgmt-attestation-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/17/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: attestation
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-automation-readme.md
+++ b/docs-ref-services/latest/mgmt-automation-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/04/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: automation
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-azurearcdata-readme.md
+++ b/docs-ref-services/latest/mgmt-azurearcdata-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: azure-arc
 ms.subservice: azure-arc-data
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-azurestack-readme.md
+++ b/docs-ref-services/latest/mgmt-azurestack-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/09/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-stack
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-baremetalinfrastructure-readme.md
+++ b/docs-ref-services/latest/mgmt-baremetalinfrastructure-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/14/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: baremetal-infrastructure
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-changeanalysis-readme.md
+++ b/docs-ref-services/latest/mgmt-changeanalysis-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: azure-monitor
 ms.subservice: change-analysis
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-commerce-readme.md
+++ b/docs-ref-services/latest/mgmt-commerce-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/04/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-databoxedge-readme.md
+++ b/docs-ref-services/latest/mgmt-databoxedge-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: databox
 ms.subservice: edge
-ms.technology: azure
 ---
 # Microsoft Azure Data Box Edge SDK for Python
 

--- a/docs-ref-services/latest/mgmt-datamigration-readme.md
+++ b/docs-ref-services/latest/mgmt-datamigration-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/26/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: dms
-ms.technology: azure
 ---
 # Microsoft Azure Data Migration SDK for Python
 

--- a/docs-ref-services/latest/mgmt-datashare-readme.md
+++ b/docs-ref-services/latest/mgmt-datashare-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/12/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: data-share
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-deploymentmanager-readme.md
+++ b/docs-ref-services/latest/mgmt-deploymentmanager-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/20/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: deployment-manager
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-devtestlabs-readme.md
+++ b/docs-ref-services/latest/mgmt-devtestlabs-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/04/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: devtest-lab
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-edgeorder-readme.md
+++ b/docs-ref-services/latest/mgmt-edgeorder-readme.md
@@ -5,7 +5,6 @@ ms.date: 12/23/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-elastic-readme.md
+++ b/docs-ref-services/latest/mgmt-elastic-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/04/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-hanaonazure-readme.md
+++ b/docs-ref-services/latest/mgmt-hanaonazure-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: sap-on-azure
 ms.subservice: sap-large-instances
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-hdinsight-readme.md
+++ b/docs-ref-services/latest/mgmt-hdinsight-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/12/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: hdinsight
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-hybridkubernetes-readme.md
+++ b/docs-ref-services/latest/mgmt-hybridkubernetes-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/20/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-kubernetes-service
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-iotcentral-readme.md
+++ b/docs-ref-services/latest/mgmt-iotcentral-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/11/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: iot-hub
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-iothubprovisioningservices-readme.md
+++ b/docs-ref-services/latest/mgmt-iothubprovisioningservices-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: iot-hub
 ms.subservice: azure-iot-hub-device-provisioning-service
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-loganalytics-readme.md
+++ b/docs-ref-services/latest/mgmt-loganalytics-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/17/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: log-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-logz-readme.md
+++ b/docs-ref-services/latest/mgmt-logz-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: partner-services
 ms.subservice: logzio
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-machinelearningservices-readme.md
+++ b/docs-ref-services/latest/mgmt-machinelearningservices-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/04/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: machine-learning
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
     

--- a/docs-ref-services/latest/mgmt-managedservices-readme.md
+++ b/docs-ref-services/latest/mgmt-managedservices-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: active-directory
 ms.subservice: msi
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-managementgroups-readme.md
+++ b/docs-ref-services/latest/mgmt-managementgroups-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: azure-resource-manager
 ms.subservice: management
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-managementpartner-readme.md
+++ b/docs-ref-services/latest/mgmt-managementpartner-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: azure-resource-manager
 ms.subservice: management
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-marketplaceordering-readme.md
+++ b/docs-ref-services/latest/mgmt-marketplaceordering-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/18/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: marketplace
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-mixedreality-readme.md
+++ b/docs-ref-services/latest/mgmt-mixedreality-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/28/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-notificationhubs-readme.md
+++ b/docs-ref-services/latest/mgmt-notificationhubs-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/06/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: notification-hubs
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-operationsmanagement-readme.md
+++ b/docs-ref-services/latest/mgmt-operationsmanagement-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/04/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-peering-readme.md
+++ b/docs-ref-services/latest/mgmt-peering-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/25/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: peering-service
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-policyinsights-readme.md
+++ b/docs-ref-services/latest/mgmt-policyinsights-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/02/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-policy
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-portal-readme.md
+++ b/docs-ref-services/latest/mgmt-portal-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/21/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-portal
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-powerbidedicated-readme.md
+++ b/docs-ref-services/latest/mgmt-powerbidedicated-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/29/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: powerbi
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-purview-readme.md
+++ b/docs-ref-services/latest/mgmt-purview-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/16/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: purview
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-rdbms-readme.md
+++ b/docs-ref-services/latest/mgmt-rdbms-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/07/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: mysql
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-relay-readme.md
+++ b/docs-ref-services/latest/mgmt-relay-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/06/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: service-bus-relay
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-resourcegraph-readme.md
+++ b/docs-ref-services/latest/mgmt-resourcegraph-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/12/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: resource-graph
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-serialconsole-readme.md
+++ b/docs-ref-services/latest/mgmt-serialconsole-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/21/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-sql-readme.md
+++ b/docs-ref-services/latest/mgmt-sql-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/16/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: sql
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-storagepool-readme.md
+++ b/docs-ref-services/latest/mgmt-storagepool-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/14/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: storage
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-storagesync-readme.md
+++ b/docs-ref-services/latest/mgmt-storagesync-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/09/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: storage
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-synapse-readme.md
+++ b/docs-ref-services/latest/mgmt-synapse-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/08/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/mgmt-timeseriesinsights-readme.md
+++ b/docs-ref-services/latest/mgmt-timeseriesinsights-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/29/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: time-series-insights
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/monitor-nspkg-readme.md
+++ b/docs-ref-services/latest/monitor-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/05/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-monitor
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/network.md
+++ b/docs-ref-services/latest/network.md
@@ -5,7 +5,6 @@ ms.date: 09/25/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: network
-ms.technology: azure
 keywords: Azure, python, SDK, API, Network
 manager: douge
 ---

--- a/docs-ref-services/latest/other.md
+++ b/docs-ref-services/latest/other.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Other libraries for python

--- a/docs-ref-services/latest/purview-nspkg-readme.md
+++ b/docs-ref-services/latest/purview-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/06/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: purview
-ms.technology: azure
 ---
 # Microsoft Azure Purview SDK for Python
 

--- a/docs-ref-services/latest/security-attestation-readme.md
+++ b/docs-ref-services/latest/security-attestation-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/06/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: attestation
-ms.technology: azure
 ---
 # Azure Attestation client library for Python - version 1.0.0 
 

--- a/docs-ref-services/latest/servicefabric-readme.md
+++ b/docs-ref-services/latest/servicefabric-readme.md
@@ -5,7 +5,6 @@ ms.date: 12/14/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: service-fabric
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/storage-fileshare-readme.md
+++ b/docs-ref-services/latest/storage-fileshare-readme.md
@@ -6,7 +6,6 @@ ms.date: 03/12/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: storage
-ms.technology: azure
 manager: twolley
 ---
 # Azure Files for Python Readme - Version 12.1.1

--- a/docs-ref-services/latest/synapse-accesscontrol-readme.md
+++ b/docs-ref-services/latest/synapse-accesscontrol-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/10/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/synapse-artifacts-readme.md
+++ b/docs-ref-services/latest/synapse-artifacts-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/10/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/synapse-managedprivateendpoints-readme.md
+++ b/docs-ref-services/latest/synapse-managedprivateendpoints-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/10/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/synapse-monitoring-readme.md
+++ b/docs-ref-services/latest/synapse-monitoring-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/09/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/latest/synapse-readme.md
+++ b/docs-ref-services/latest/synapse-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/14/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure Synapse SDK for Python
 

--- a/docs-ref-services/latest/synapse-spark-readme.md
+++ b/docs-ref-services/latest/synapse-spark-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/10/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/adls-gen1-client.md
+++ b/docs-ref-services/legacy/adls-gen1-client.md
@@ -6,7 +6,6 @@ ms.date: 08/26/2019
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-data-lake-storage
-ms.technology: azure
 manager: pkasturi
 ---
 # azure-datalake-store

--- a/docs-ref-services/legacy/ai-formrecognizer-readme.md
+++ b/docs-ref-services/legacy/ai-formrecognizer-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: applied-ai-services
 ms.subservice: forms-recognizer
-ms.technology: azure
 ---
 # Azure Form Recognizer client library for Python - version 3.0.0 
 

--- a/docs-ref-services/legacy/ai-metricsadvisor-readme.md
+++ b/docs-ref-services/legacy/ai-metricsadvisor-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: metrics-advisor
-ms.technology: azure
 ---
 # Azure Metrics Advisor client library for Python - version 1.0.0b4 
 

--- a/docs-ref-services/legacy/ai-textanalytics-readme.md
+++ b/docs-ref-services/legacy/ai-textanalytics-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: Python
 ms.service: cognitive-services
 ms.subservice: text-analytics
-ms.technology: azure
 ---
 # Azure Text Analytics client library for Python - version 5.0.0 
 Text Analytics is a cloud-based service that provides advanced natural language processing over raw text, and includes six main functions:

--- a/docs-ref-services/legacy/app-service.md
+++ b/docs-ref-services/legacy/app-service.md
@@ -6,7 +6,6 @@ ms.date: 06/12/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: app-service
-ms.technology: azure
 manager: douge
 ---
 # Azure Web Apps libraries for Python

--- a/docs-ref-services/legacy/appconfiguration-readme.md
+++ b/docs-ref-services/legacy/appconfiguration-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/05/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-app-configuration
-ms.technology: azure
 ---
 # Azure App Configuration client library for Python - version 1.1.1 
 

--- a/docs-ref-services/legacy/applicationinsights-readme.md
+++ b/docs-ref-services/legacy/applicationinsights-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: application-insights
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/authorization.md
+++ b/docs-ref-services/legacy/authorization.md
@@ -6,7 +6,6 @@ ms.date: 02/21/2018
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: routlaw
 ---
 # Azure Authorization libraries for python

--- a/docs-ref-services/legacy/azure.mgmt.resource.md
+++ b/docs-ref-services/legacy/azure.mgmt.resource.md
@@ -6,7 +6,6 @@ ms.date: 06/19/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Resources libraries for Python 

--- a/docs-ref-services/legacy/batch.md
+++ b/docs-ref-services/legacy/batch.md
@@ -6,7 +6,6 @@ ms.date: 07/31/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: batch
-ms.technology: azure
 manager: douge
 ---
 # Azure Batch libraries for python

--- a/docs-ref-services/legacy/cognitive-services.md
+++ b/docs-ref-services/legacy/cognitive-services.md
@@ -5,7 +5,6 @@ ms.date: 09/25/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: cognitiveservices
-ms.technology: azure
 keywords: Azure, python, SDK, API, Cognitive Services
 manager: angerobe
 ---

--- a/docs-ref-services/legacy/cognitiveservices-language-spellcheck-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-language-spellcheck-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-spell-check
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/cognitiveservices-vision-computervision-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-vision-computervision-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: computer-vision
-ms.technology: azure
 ---
 # Azure Cognitive Services Computer Vision SDK for Python
 

--- a/docs-ref-services/legacy/cognitiveservices-vision-customvision-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-vision-customvision-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: custom-vision
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/cognitiveservices/bing-custom-image-search-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices/bing-custom-image-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Image Search
 

--- a/docs-ref-services/legacy/cognitiveservices/bing-custom-search-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices/bing-custom-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Search
 

--- a/docs-ref-services/legacy/cognitiveservices/bing-entity-search-api-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices/bing-entity-search-api-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Entity Search
 

--- a/docs-ref-services/legacy/cognitiveservices/bing-image-search-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices/bing-image-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Image Search
 

--- a/docs-ref-services/legacy/cognitiveservices/bing-news-search-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices/bing-news-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing News Search
 

--- a/docs-ref-services/legacy/cognitiveservices/bing-video-search-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices/bing-video-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Video Search
 

--- a/docs-ref-services/legacy/cognitiveservices/bing-visual-search-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices/bing-visual-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Visual Search
 

--- a/docs-ref-services/legacy/cognitiveservices/bing-web-search-api-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices/bing-web-search-api-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Web Search API
 

--- a/docs-ref-services/legacy/commerce.md
+++ b/docs-ref-services/legacy/commerce.md
@@ -6,7 +6,6 @@ ms.date: 02/21/2018
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: routlaw
 ---
 # Azure Commerce libraries for python

--- a/docs-ref-services/legacy/common-readme.md
+++ b/docs-ref-services/legacy/common-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/11/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/compute.md
+++ b/docs-ref-services/legacy/compute.md
@@ -6,7 +6,6 @@ ms.date: 06/09/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: big-compute
-ms.technology: azure
 manager: douge
 ---
 # Azure virtual machine libraries

--- a/docs-ref-services/legacy/consumption.md
+++ b/docs-ref-services/legacy/consumption.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Consumption libraries for python

--- a/docs-ref-services/legacy/container-registry.md
+++ b/docs-ref-services/legacy/container-registry.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: container-registry
-ms.technology: azure
 manager: douge
 ---
 # Azure Container Registry libraries for python

--- a/docs-ref-services/legacy/core-readme.md
+++ b/docs-ref-services/legacy/core-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/09/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Azure Core shared client library for Python - version 1.9.0 
 

--- a/docs-ref-services/legacy/cosmos-readme.md
+++ b/docs-ref-services/legacy/cosmos-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/09/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: cosmos-db
-ms.technology: azure
 ---
 # Azure Cosmos DB SQL API client library for Python - version 4.2.0 
 

--- a/docs-ref-services/legacy/data-factory.md
+++ b/docs-ref-services/legacy/data-factory.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: data-factory
 manager: angerobe
-ms.technology: azure
 ---
 # Azure Data Factory libraries for Python
 

--- a/docs-ref-services/legacy/data-lake-analytics.md
+++ b/docs-ref-services/legacy/data-lake-analytics.md
@@ -6,7 +6,6 @@ ms.date: 08/04/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: data-lake-analytics
-ms.technology: azure
 manager: douge
 ---
 # Azure Data Lake Analytics libraries for python

--- a/docs-ref-services/legacy/data-lake-storage-(gen-1).md
+++ b/docs-ref-services/legacy/data-lake-storage-(gen-1).md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-data-lake-storage
-ms.technology: azure
 manager: douge
 ---
 # Azure Data Lake Store libraries for python

--- a/docs-ref-services/legacy/data-nspkg-readme.md
+++ b/docs-ref-services/legacy/data-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure Data SDK for Python
 

--- a/docs-ref-services/legacy/database-for-mysql-postgres.md
+++ b/docs-ref-services/legacy/database-for-mysql-postgres.md
@@ -5,7 +5,6 @@ keywords: Azure, Python, SDK, API, SQL, database, MySQL, PostgreSQL
 ms.date: 10/02/2019
 ms.topic: reference
 ms.devlang: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Database for MySQL/PostgreSQL libraries for Python

--- a/docs-ref-services/legacy/devtest-labs.md
+++ b/docs-ref-services/legacy/devtest-labs.md
@@ -6,7 +6,6 @@ ms.date: 02/21/2018
 ms.topic: reference
 ms.devlang: python
 ms.service: devtest-lab
-ms.technology: azure
 manager: routlaw
 ---
 # Azure DevTest Labs libraries for python

--- a/docs-ref-services/legacy/digitaltwins-core-readme.md
+++ b/docs-ref-services/legacy/digitaltwins-core-readme.md
@@ -5,7 +5,6 @@ ms.date: 12/01/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: digital-twins
-ms.technology: azure
 ---
 # Azure Azure Digital Twins Core client library for Python - version 1.1.0 
 

--- a/docs-ref-services/legacy/dns.md
+++ b/docs-ref-services/legacy/dns.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: dns
-ms.technology: azure
 manager: douge
 ---
 # Azure DNS libraries for python

--- a/docs-ref-services/legacy/event-hubs.md
+++ b/docs-ref-services/legacy/event-hubs.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 manager: douge
 ---
 # Azure Event Hubs libraries for python

--- a/docs-ref-services/legacy/eventhub-checkpointstoreblob-aio-readme.md
+++ b/docs-ref-services/legacy/eventhub-checkpointstoreblob-aio-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure EventHubs Checkpoint Store client library for Python - version 1.1.1 
  using Storage Blobs

--- a/docs-ref-services/legacy/eventhub-checkpointstoreblob-readme.md
+++ b/docs-ref-services/legacy/eventhub-checkpointstoreblob-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure EventHubs Checkpoint Store client library for Python - version 1.1.1 
  using Storage Blobs

--- a/docs-ref-services/legacy/eventhub-readme.md
+++ b/docs-ref-services/legacy/eventhub-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure Event Hubs client library for Python - version 5.2.0 
 

--- a/docs-ref-services/legacy/identity-readme.md
+++ b/docs-ref-services/legacy/identity-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: active-directory
 ms.subservice: identity-protection
-ms.technology: azure
 ---
 # Azure Identity client library for Python - version 1.5.0 
 

--- a/docs-ref-services/legacy/iot.md
+++ b/docs-ref-services/legacy/iot.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: iot-hub
-ms.technology: azure
 manager: douge
 ---
 # Azure IoT Hub libraries for python

--- a/docs-ref-services/legacy/keyvault-certificates-readme.md
+++ b/docs-ref-services/legacy/keyvault-certificates-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Certificates client library for Python - version 4.2.1 
 

--- a/docs-ref-services/legacy/keyvault-keys-readme.md
+++ b/docs-ref-services/legacy/keyvault-keys-readme.md
@@ -5,7 +5,6 @@ ms.date: 12/03/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Keys client library for Python - version 4.3.1 
 

--- a/docs-ref-services/legacy/loganalytics-readme.md
+++ b/docs-ref-services/legacy/loganalytics-readme.md
@@ -5,8 +5,6 @@ ms.date: 11/12/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: loganalytics
-ms.technology: azure
-ms.prod: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/logic-apps.md
+++ b/docs-ref-services/legacy/logic-apps.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: logic-apps
-ms.technology: azure
 manager: douge
 ---
 # Azure Logic Apps libraries for python

--- a/docs-ref-services/legacy/media-services.md
+++ b/docs-ref-services/legacy/media-services.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: media-services
-ms.technology: azure
 manager: douge
 ---
 # Azure Media Services libraries for python

--- a/docs-ref-services/legacy/mgmt-appconfiguration-readme.md
+++ b/docs-ref-services/legacy/mgmt-appconfiguration-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-app-configuration
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-appplatform-readme.md
+++ b/docs-ref-services/legacy/mgmt-appplatform-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-attestation-readme.md
+++ b/docs-ref-services/legacy/mgmt-attestation-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: attestation
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-authorization-readme.md
+++ b/docs-ref-services/legacy/mgmt-authorization-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-avs-readme.md
+++ b/docs-ref-services/legacy/mgmt-avs-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/11/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-vmware
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-azurestackhci-readme.md
+++ b/docs-ref-services/legacy/mgmt-azurestackhci-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: azure-stack
 ms.subservice: azure-stack-hci
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-batchai-readme.md
+++ b/docs-ref-services/legacy/mgmt-batchai-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: batch-ai
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-billing-readme.md
+++ b/docs-ref-services/legacy/mgmt-billing-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/20/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: cost-management-billing
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-cdn-readme.md
+++ b/docs-ref-services/legacy/mgmt-cdn-readme.md
@@ -5,7 +5,6 @@ ms.date: 12/01/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-cdn
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-cognitiveservices-readme.md
+++ b/docs-ref-services/legacy/mgmt-cognitiveservices-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/13/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-compute-readme.md
+++ b/docs-ref-services/legacy/mgmt-compute-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: big-compute
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-containerinstance-readme.md
+++ b/docs-ref-services/legacy/mgmt-containerinstance-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: container-instances
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-containerservice-readme.md
+++ b/docs-ref-services/legacy/mgmt-containerservice-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: container-service
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-core-readme.md
+++ b/docs-ref-services/legacy/mgmt-core-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/09/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Azure Management Core Library
 

--- a/docs-ref-services/legacy/mgmt-cosmosdb-readme.md
+++ b/docs-ref-services/legacy/mgmt-cosmosdb-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: cosmos-db
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-databoxedge-readme.md
+++ b/docs-ref-services/legacy/mgmt-databoxedge-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: databox
 ms.subservice: edge
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-datafactory-readme.md
+++ b/docs-ref-services/legacy/mgmt-datafactory-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/04/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: data-factory
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-datamigration-readme.md
+++ b/docs-ref-services/legacy/mgmt-datamigration-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/22/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: dms
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-digitaltwins-readme.md
+++ b/docs-ref-services/legacy/mgmt-digitaltwins-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/22/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: digital-twins
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-eventhub-readme.md
+++ b/docs-ref-services/legacy/mgmt-eventhub-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-hdinsight-readme.md
+++ b/docs-ref-services/legacy/mgmt-hdinsight-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/23/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: hdinsight
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-healthcareapis-readme.md
+++ b/docs-ref-services/legacy/mgmt-healthcareapis-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/30/2020
 ms.topic: article
 ms.devlang: python
 ms.service: healthcare-apis
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-hybridcompute-readme.md
+++ b/docs-ref-services/legacy/mgmt-hybridcompute-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-keyvault-readme.md
+++ b/docs-ref-services/legacy/mgmt-keyvault-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-kusto-readme.md
+++ b/docs-ref-services/legacy/mgmt-kusto-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: kusto
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-loganalytics-readme.md
+++ b/docs-ref-services/legacy/mgmt-loganalytics-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/17/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: log-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-media-readme.md
+++ b/docs-ref-services/legacy/mgmt-media-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/21/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: media-services
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-monitor-readme.md
+++ b/docs-ref-services/legacy/mgmt-monitor-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/17/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-monitor
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-netapp-readme.md
+++ b/docs-ref-services/legacy/mgmt-netapp-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/16/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-netapp-files
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-network-readme.md
+++ b/docs-ref-services/legacy/mgmt-network-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-policyinsights-readme.md
+++ b/docs-ref-services/legacy/mgmt-policyinsights-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/11/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-policy
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-redis-readme.md
+++ b/docs-ref-services/legacy/mgmt-redis-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: cache
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-resource-readme.md
+++ b/docs-ref-services/legacy/mgmt-resource-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-resource-manager
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-search-readme.md
+++ b/docs-ref-services/legacy/mgmt-search-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/30/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-security-readme.md
+++ b/docs-ref-services/legacy/mgmt-security-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/17/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-servicebus-readme.md
+++ b/docs-ref-services/legacy/mgmt-servicebus-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: service-bus
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-sql-readme.md
+++ b/docs-ref-services/legacy/mgmt-sql-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: sql
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-storage-readme.md
+++ b/docs-ref-services/legacy/mgmt-storage-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: storage
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-subscription-readme.md
+++ b/docs-ref-services/legacy/mgmt-subscription-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/12/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-synapse-readme.md
+++ b/docs-ref-services/legacy/mgmt-synapse-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/24/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/mgmt-web-readme.md
+++ b/docs-ref-services/legacy/mgmt-web-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: app-service
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/microsoft-graph.md
+++ b/docs-ref-services/legacy/microsoft-graph.md
@@ -6,7 +6,6 @@ ms.date: 05/10/2019
 ms.topic: reference
 ms.devlang: python
 ms.service: active-directory
-ms.technology: azure
 manager: jfriend
 ---
 # Azure Active Directory Graph libraries for Python

--- a/docs-ref-services/legacy/monitoring.md
+++ b/docs-ref-services/legacy/monitoring.md
@@ -6,7 +6,6 @@ ms.date: 07/19/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-monitor
-ms.technology: azure
 manager: douge
 ---
 # Azure Monitoring libraries for python

--- a/docs-ref-services/legacy/network.md
+++ b/docs-ref-services/legacy/network.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: virtual-network
-ms.technology: azure
 manager: douge
 ---
 # Azure Network libraries for python

--- a/docs-ref-services/legacy/notification-hubs.md
+++ b/docs-ref-services/legacy/notification-hubs.md
@@ -6,7 +6,6 @@ ms.date: 02/22/2018
 ms.topic: reference
 ms.devlang: python
 ms.service: notification-hubs
-ms.technology: azure
 manager: routlaw
 ---
 # Azure Notification Hubs libraries for python

--- a/docs-ref-services/legacy/other.md
+++ b/docs-ref-services/legacy/other.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Other libraries for python

--- a/docs-ref-services/legacy/power-bi.md
+++ b/docs-ref-services/legacy/power-bi.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: powerbi
-ms.technology: azure
 manager: douge
 ---
 # Azure PowerBI libraries for python

--- a/docs-ref-services/legacy/scheduler.md
+++ b/docs-ref-services/legacy/scheduler.md
@@ -6,7 +6,6 @@ ms.date: 02/21/2018
 ms.topic: reference
 ms.devlang: python
 ms.service: scheduler
-ms.technology: azure
 manager: mbaldwin
 ---
 # Azure Scheduler libraries for python

--- a/docs-ref-services/legacy/search.md
+++ b/docs-ref-services/legacy/search.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: search
-ms.technology: azure
 manager: douge
 ---
 # Azure Search libraries for python

--- a/docs-ref-services/legacy/servicebus-readme.md
+++ b/docs-ref-services/legacy/servicebus-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/24/2020
 ms.topic: reference
 ms.devlang: 
 ms.service: service-bus
-ms.technology: azure
 ---
 # Azure Service Bus client library for Python - version 7.0.0 
 

--- a/docs-ref-services/legacy/site-recovery.md
+++ b/docs-ref-services/legacy/site-recovery.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: site-recovery
-ms.technology: azure
 manager: douge
 ---
 # Azure Recovery Services Backup libraries for python

--- a/docs-ref-services/legacy/storage-blob-readme.md
+++ b/docs-ref-services/legacy/storage-blob-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: storage
 ms.subservice: blobs
-ms.technology: azure
 ---
 # Azure Storage Blobs client library for Python - version 12.6.0 
 

--- a/docs-ref-services/legacy/storage-file-datalake-readme.md
+++ b/docs-ref-services/legacy/storage-file-datalake-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/11/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: data-lake-storage-gen2
-ms.technology: azure
 ---
 # Azure DataLake service client library for Python - version 12.2.0 
 

--- a/docs-ref-services/legacy/storage-file-share-readme.md
+++ b/docs-ref-services/legacy/storage-file-share-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: storage
 ms.subservice: files
-ms.technology: azure
 ---
 # Azure Storage File Share client library for Python - version 12.3.0 
 

--- a/docs-ref-services/legacy/storage-fileshare-readme.md
+++ b/docs-ref-services/legacy/storage-fileshare-readme.md
@@ -7,7 +7,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: storage
 ms.subservice: files
-ms.technology: azure
 manager: twolley
 ---
 # Azure Files for Python Readme - Version 12.1.1

--- a/docs-ref-services/legacy/storage-queue-readme.md
+++ b/docs-ref-services/legacy/storage-queue-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: storage
 ms.subservice: queues
-ms.technology: azure
 ---
 # Azure Storage Queues client library for Python - version 12.1.4 
 

--- a/docs-ref-services/legacy/storage.md
+++ b/docs-ref-services/legacy/storage.md
@@ -5,7 +5,6 @@ ms.date: 09/25/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: storage
-ms.technology: azure
 keywords: Azure, Python, SDK, API, Storage
 manager: douge
 ---

--- a/docs-ref-services/legacy/synapse-accesscontrol-readme.md
+++ b/docs-ref-services/legacy/synapse-accesscontrol-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/03/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/synapse-artifacts-readme.md
+++ b/docs-ref-services/legacy/synapse-artifacts-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/03/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/synapse-spark-readme.md
+++ b/docs-ref-services/legacy/synapse-spark-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
 ms.subservice: spark
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/legacy/traffic-manager.md
+++ b/docs-ref-services/legacy/traffic-manager.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: traffic-manager
-ms.technology: azure
 manager: douge
 ---
 # Azure Traffic Manager libraries for python

--- a/docs-ref-services/mgmt-loganalytics-readme-pre.md
+++ b/docs-ref-services/mgmt-loganalytics-readme-pre.md
@@ -5,7 +5,6 @@ ms.date: 11/17/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: log-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/adls-gen1-client.md
+++ b/docs-ref-services/preview/adls-gen1-client.md
@@ -6,7 +6,6 @@ ms.date: 08/26/2019
 ms.topic: reference
 ms.devlang: python
 ms.service: data-lake-store
-ms.technology: azure
 manager: pkasturi
 ---
 # azure-datalake-store

--- a/docs-ref-services/preview/app-service.md
+++ b/docs-ref-services/preview/app-service.md
@@ -6,7 +6,6 @@ ms.date: 06/12/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: app-service
-ms.technology: azure
 manager: douge
 ---
 # Azure Web Apps libraries for Python

--- a/docs-ref-services/preview/authorization.md
+++ b/docs-ref-services/preview/authorization.md
@@ -7,7 +7,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: authorization
 manager: routlaw
-ms.technology: azure
 ---
 # Azure Authorization libraries for python
 

--- a/docs-ref-services/preview/azure-keyvault-keys-readme.md
+++ b/docs-ref-services/preview/azure-keyvault-keys-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/05/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Keys client library for Python - version 4.5.0a20211005001 
 

--- a/docs-ref-services/preview/azure-template-readme.md
+++ b/docs-ref-services/preview/azure-template-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/27/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 [![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/azure-sdk-for-python.client?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=46?branchName=master)
 

--- a/docs-ref-services/preview/azure.mgmt.resource.md
+++ b/docs-ref-services/preview/azure.mgmt.resource.md
@@ -6,7 +6,6 @@ ms.date: 06/19/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Resources libraries for Python 

--- a/docs-ref-services/preview/cognitiveservices-personalizer-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-personalizer-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: personalizer
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-autosuggest-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-autosuggest-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-autosuggest
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-customimagesearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-customimagesearch-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-image-search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-customsearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-customsearch-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-custom-search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-entitysearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-entitysearch-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-entity-search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-imagesearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-imagesearch-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-image-search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-newssearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-newssearch-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-news-search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-videosearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-videosearch-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-video-search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-visualsearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-visualsearch-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-visual-search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-search-websearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-search-websearch-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: bing-web-search
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-vision-computervision-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-vision-computervision-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: computer-vision
-ms.technology: azure
 ---
 # Azure Cognitive Services Computer Vision SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-vision-contentmoderator-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-vision-contentmoderator-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: content-moderator
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices-vision-customvision-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-vision-customvision-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cognitive-services
 ms.subservice: custom-vision
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/cognitiveservices/bing-custom-image-search-readme.md
+++ b/docs-ref-services/preview/cognitiveservices/bing-custom-image-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Image Search
 

--- a/docs-ref-services/preview/cognitiveservices/bing-custom-search-readme.md
+++ b/docs-ref-services/preview/cognitiveservices/bing-custom-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Search
 

--- a/docs-ref-services/preview/cognitiveservices/bing-entity-search-api-readme.md
+++ b/docs-ref-services/preview/cognitiveservices/bing-entity-search-api-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Entity Search
 

--- a/docs-ref-services/preview/cognitiveservices/bing-image-search-readme.md
+++ b/docs-ref-services/preview/cognitiveservices/bing-image-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Image Search
 

--- a/docs-ref-services/preview/cognitiveservices/bing-news-search-readme.md
+++ b/docs-ref-services/preview/cognitiveservices/bing-news-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing News Search
 

--- a/docs-ref-services/preview/cognitiveservices/bing-video-search-readme.md
+++ b/docs-ref-services/preview/cognitiveservices/bing-video-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Video Search
 

--- a/docs-ref-services/preview/cognitiveservices/bing-visual-search-readme.md
+++ b/docs-ref-services/preview/cognitiveservices/bing-visual-search-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Visual Search
 

--- a/docs-ref-services/preview/cognitiveservices/bing-web-search-api-readme.md
+++ b/docs-ref-services/preview/cognitiveservices/bing-web-search-api-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Web Search API
 

--- a/docs-ref-services/preview/commerce.md
+++ b/docs-ref-services/preview/commerce.md
@@ -5,7 +5,6 @@ ms.date: 09/25/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: commerce
-ms.technology: azure
 keywords: Azure, python, SDK, API, Commerce
 manager: routlaw
 ---

--- a/docs-ref-services/preview/communication-administration-readme.md
+++ b/docs-ref-services/preview/communication-administration-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/05/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 [![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/azure-sdk-for-python.client?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=46?branchName=master)
 

--- a/docs-ref-services/preview/communication-chat-readme.md
+++ b/docs-ref-services/preview/communication-chat-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: azure-communication-services
 ms.subservice: chat
-ms.technology: azure
 ---
 # Azure Communication Chat Package client library for Python - version 1.1.0b1 
 

--- a/docs-ref-services/preview/communication-nspkg-readme.md
+++ b/docs-ref-services/preview/communication-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/05/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Microsoft Azure Communication SDK for Python
 

--- a/docs-ref-services/preview/communication-sms-readme.md
+++ b/docs-ref-services/preview/communication-sms-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: azure-communication-services
 ms.subservice: sms
-ms.technology: azure
 ---
 [![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/azure-sdk-for-python.client?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=46?branchName=master)
 

--- a/docs-ref-services/preview/confidentialledger-readme.md
+++ b/docs-ref-services/preview/confidentialledger-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: confidential-ledger
-ms.technology: azure
 ---
 # Azure Confidential Ledger client library for Python - version 1.0.0a20220330001 
 

--- a/docs-ref-services/preview/consumption.md
+++ b/docs-ref-services/preview/consumption.md
@@ -5,7 +5,6 @@ ms.date: 09/25/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: consumption
-ms.technology: azure
 keywords: Azure, python, SDK, API, Consumption
 manager: douge
 ---

--- a/docs-ref-services/preview/core-readme.md
+++ b/docs-ref-services/preview/core-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/13/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Azure Core shared client library for Python - version 1.15.0b1 
 

--- a/docs-ref-services/preview/core-tracing-opencensus-readme.md
+++ b/docs-ref-services/preview/core-tracing-opencensus-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/01/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Azure Core Tracing OpenCensus client library for Python - version 1.0.0b8 
 

--- a/docs-ref-services/preview/cost-management-+-billing.md
+++ b/docs-ref-services/preview/cost-management-+-billing.md
@@ -7,7 +7,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cost-management-billing
 manager: douge
-ms.technology: azure
 ---
 # Azure Billing libraries for python
 

--- a/docs-ref-services/preview/data-factory.md
+++ b/docs-ref-services/preview/data-factory.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: data-factory
 manager: angerobe
-ms.technology: azure
 ---
 # Azure Data Factory libraries for Python
 

--- a/docs-ref-services/preview/data-lake-analytics.md
+++ b/docs-ref-services/preview/data-lake-analytics.md
@@ -7,7 +7,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: data-lake-analytics
 manager: douge
-ms.technology: azure
 ---
 # Azure Data Lake Analytics libraries for python
 

--- a/docs-ref-services/preview/data-lake-storage-(gen-1).md
+++ b/docs-ref-services/preview/data-lake-storage-(gen-1).md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: data-lake-store
-ms.technology: azure
 manager: douge
 ---
 # Azure Data Lake Store libraries for python

--- a/docs-ref-services/preview/data-nspkg-readme.md
+++ b/docs-ref-services/preview/data-nspkg-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Azure Data SDK for Python
 

--- a/docs-ref-services/preview/data-tables-readme.md
+++ b/docs-ref-services/preview/data-tables-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/13/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: storage
-ms.technology: azure
 ---
 # Azure Data Tables client library for Python - version 12.0.0b7 
 

--- a/docs-ref-services/preview/database-for-mysql-postgres.md
+++ b/docs-ref-services/preview/database-for-mysql-postgres.md
@@ -6,7 +6,6 @@ ms.date: 10/02/2019
 ms.topic: reference
 ms.devlang: python
 ms.service: mysql
-ms.technology: azure
 manager: douge
 ---
 # Azure Database for MySQL/PostgreSQL libraries for Python

--- a/docs-ref-services/preview/devtest-labs.md
+++ b/docs-ref-services/preview/devtest-labs.md
@@ -5,7 +5,6 @@ ms.date: 09/25/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: devtest-lab
-ms.technology: azure
 keywords: Azure, python, SDK, API, DevTest Labs
 manager: routlaw
 ---

--- a/docs-ref-services/preview/eventhub-checkpointstoreblob-aio-readme.md
+++ b/docs-ref-services/preview/eventhub-checkpointstoreblob-aio-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure EventHubs Checkpoint Store client library for Python - version 1.1.1 
  using Storage Blobs

--- a/docs-ref-services/preview/eventhub-checkpointstoreblob-readme.md
+++ b/docs-ref-services/preview/eventhub-checkpointstoreblob-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure EventHubs Checkpoint Store client library for Python - version 1.1.1 
  using Storage Blobs

--- a/docs-ref-services/preview/iot-modelsrepository-readme.md
+++ b/docs-ref-services/preview/iot-modelsrepository-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Azure IoT Models Repository client library for Python - version 1.0.0a20220330001 
 

--- a/docs-ref-services/preview/logic-apps.md
+++ b/docs-ref-services/preview/logic-apps.md
@@ -5,7 +5,6 @@ ms.date: 09/25/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: logicapps
-ms.technology: azure
 keywords: Azure, python, SDK, API, Logic Apps
 manager: douge
 ---

--- a/docs-ref-services/preview/media-analytics-edge-readme.md
+++ b/docs-ref-services/preview/media-analytics-edge-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/10/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-video-analyzer
-ms.technology: azure
 ---
 # Azure Live Video Analytics for IoT Edge client library for Python - version 1.0.0b2 
 

--- a/docs-ref-services/preview/media-services.md
+++ b/docs-ref-services/preview/media-services.md
@@ -7,8 +7,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: mediaservices
 manager: douge
-ms.prod: azure
-ms.technology: azure
 ---
 # Azure Media Services libraries for python
 

--- a/docs-ref-services/preview/mgmt-batch-readme.md
+++ b/docs-ref-services/preview/mgmt-batch-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: batch
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-containerregistry-readme.md
+++ b/docs-ref-services/preview/mgmt-containerregistry-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: container-registry
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-containerservice-readme.md
+++ b/docs-ref-services/preview/mgmt-containerservice-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: container-service
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-core-readme.md
+++ b/docs-ref-services/preview/mgmt-core-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/05/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Azure Management Core Library
 

--- a/docs-ref-services/preview/mgmt-costmanagement-readme.md
+++ b/docs-ref-services/preview/mgmt-costmanagement-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: cost-management-billing
 ms.subservice: cost-management
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-datafactory-readme.md
+++ b/docs-ref-services/preview/mgmt-datafactory-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: data-factory
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-logz-readme.md
+++ b/docs-ref-services/preview/mgmt-logz-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: partner-services
 ms.subservice: logzio
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-purview-readme.md
+++ b/docs-ref-services/preview/mgmt-purview-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/01/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: purview
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-recoveryservices-readme.md
+++ b/docs-ref-services/preview/mgmt-recoveryservices-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: site-recovery
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-redis-readme.md
+++ b/docs-ref-services/preview/mgmt-redis-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: cache
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-scheduler-readme.md
+++ b/docs-ref-services/preview/mgmt-scheduler-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/18/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: scheduler
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-servicebus-readme.md
+++ b/docs-ref-services/preview/mgmt-servicebus-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/25/2020
 ms.topic: reference
 ms.devlang: python
 ms.service: service-bus
-ms.technology: azure
 ---
 ## Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mgmt-web-readme.md
+++ b/docs-ref-services/preview/mgmt-web-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: app-service
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/mixedreality-authentication-readme.md
+++ b/docs-ref-services/preview/mixedreality-authentication-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/12/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 [![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/azure-sdk-for-python.client?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=46?branchName=master)
 

--- a/docs-ref-services/preview/network.md
+++ b/docs-ref-services/preview/network.md
@@ -7,7 +7,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: network
 manager: douge
-ms.technology: azure
 ---
 # Azure Network libraries for python
 

--- a/docs-ref-services/preview/notification-hubs.md
+++ b/docs-ref-services/preview/notification-hubs.md
@@ -5,7 +5,6 @@ ms.date: 09/25/2024
 ms.topic: reference
 ms.devlang: python
 ms.service: notificationhubs
-ms.technology: azure
 keywords: Azure, python, SDK, API, Notification Hubs
 manager: routlaw
 ---

--- a/docs-ref-services/preview/opentelemetry-exporter-azuremonitor-readme.md
+++ b/docs-ref-services/preview/opentelemetry-exporter-azuremonitor-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/14/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 ---
 # Microsoft Opentelemetry exporter for Azure Monitor
 

--- a/docs-ref-services/preview/other.md
+++ b/docs-ref-services/preview/other.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: azure-python
-ms.technology: azure
 manager: douge
 ---
 # Azure Other libraries for python

--- a/docs-ref-services/preview/power-bi.md
+++ b/docs-ref-services/preview/power-bi.md
@@ -6,7 +6,6 @@ ms.date: 07/10/2017
 ms.topic: reference
 ms.devlang: python
 ms.service: powerbi
-ms.technology: azure
 manager: douge
 ---
 # Azure PowerBI libraries for python

--- a/docs-ref-services/preview/purview-account-readme.md
+++ b/docs-ref-services/preview/purview-account-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/25/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: purview
-ms.technology: azure
 ---
 # Azure Purview Account client library for Python - version 1.0.0b1 
 

--- a/docs-ref-services/preview/purview-administration-readme.md
+++ b/docs-ref-services/preview/purview-administration-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/15/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: purview
-ms.technology: azure
 ---
 # Azure Purview Administration client library for Python - version 1.0.0b1 
 

--- a/docs-ref-services/preview/purview-scanning-readme.md
+++ b/docs-ref-services/preview/purview-scanning-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/15/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: purview
-ms.technology: azure
 ---
 # Azure Purview Scanning client library for Python - version 1.0.0b2 
 

--- a/docs-ref-services/preview/schemaregistry-avroserializer-readme.md
+++ b/docs-ref-services/preview/schemaregistry-avroserializer-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/11/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure Schema Registry Avro Serializer client library for Python - version 1.0.0b4 
 

--- a/docs-ref-services/preview/security-attestation-readme.md
+++ b/docs-ref-services/preview/security-attestation-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/10/2021
 ms.topic: reference
 ms.devlang: python
 ms.service: attestation
-ms.technology: azure
 ---
 # Azure Attestation client library for Python - version 1.0.0b4 
 

--- a/docs-ref-services/preview/storage-fileshare-readme.md
+++ b/docs-ref-services/preview/storage-fileshare-readme.md
@@ -7,7 +7,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: storage
 ms.subservice: files
-ms.technology: azure
 manager: twolley
 ---
 # Azure Files for Python Readme - Version 12.1.1

--- a/docs-ref-services/preview/synapse-accesscontrol-readme.md
+++ b/docs-ref-services/preview/synapse-accesscontrol-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/synapse-managedprivateendpoints-readme.md
+++ b/docs-ref-services/preview/synapse-managedprivateendpoints-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/synapse-monitoring-readme.md
+++ b/docs-ref-services/preview/synapse-monitoring-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/synapse-readme.md
+++ b/docs-ref-services/preview/synapse-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/31/2022
 ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Microsoft Azure Synapse SDK for Python
 

--- a/docs-ref-services/preview/synapse-spark-readme.md
+++ b/docs-ref-services/preview/synapse-spark-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: synapse-analytics
 ms.subservice: spark
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Python
 

--- a/docs-ref-services/preview/traffic-manager.md
+++ b/docs-ref-services/preview/traffic-manager.md
@@ -7,7 +7,6 @@ ms.topic: reference
 ms.devlang: python
 ms.service: trafficmanager
 manager: douge
-ms.technology: azure
 ---
 # Azure Traffic Manager libraries for python
 


### PR DESCRIPTION
These files are updated by automation, but that automation no longer attempts to include ms.prod and ms.technology metadata - they only persist because they're already on the files and the automation preserves them.