### PR TITLE
Revert "Revert "Update speech SDK for 1.46.0""

### DIFF
--- a/metadata/latest/azure-cognitiveservices-speech.json
+++ b/metadata/latest/azure-cognitiveservices-speech.json
@@ -1,5 +1,5 @@
 {
-  "Version": "1.45.0",
+  "Version": "1.46.0",
   "Name": "azure-cognitiveservices-speech",
   "ServiceDirectory": "NA",
   "SdkType": "client",


### PR DESCRIPTION
Reverts MicrosoftDocs/azure-docs-sdk-python#2010

There was a failure during last week's build which could be attributable to the speech package but it builds correctly in isolation. 

Failure: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=565446&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=82308bed-e88c-552e-8a03-cd3f5b3ab7a3

Isolated build: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=567719&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=82308bed-e88c-552e-8a03-cd3f5b3ab7a3